### PR TITLE
feat(CC-48): complete soft light/dark theming for planner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,22 @@ This is a living document maintained to track feature additions, bug fixes, and 
 
 ## [In Progress]
 
-_No active in-progress items._
-
 ---
 
 ## [Completed]
 
-<!-- Example format:
+### CC-48: Soft Light/Dark Theming for Planner - 2026-01-02
+
+- Define soft light/dark global theme tokens and planner-specific CSS variables, and load them via the app root layout
+- Add a dedicated `usePlannerTheme` hook plus `PlannerNavBar` to provide a planner-only soft light/dark toggle with persisted user preference
+- Update planner layout and calendar components (header, view, events, FullCalendar CSS) to consume the new theme tokens, including all-day row and selected-day highlighting
+- Refresh the tickets sidebar with `TicketCard` and `TicketCreateModal` components styled against the new palette while preserving drag-and-drop and scheduling behaviour
+- Implement ticket scheduling/unscheduling API integration and TODOs on planner page
+- Add shared popover positioning utility and refactor TicketCard/TicketCreateModal to use it
+- Consolidate error-utils imports to use @/utils alias consistently
+- Finalize themes.css for production (remove scaffolding comments)
+- Add toggle behavior to CalendarCard popup in TicketCard schedule button
+
 ### Project Setup & Configuration - 2025-12-31
 - Added CHANGELOG.md for tracking project changes
 - Created GitHub Copilot instructions document
@@ -44,7 +53,6 @@ _No active in-progress items._
 - [x] Add calendar picker widget for manual ticket scheduling
 - [x] Implement event/ticket API integration
 - [x] Add comprehensive error handling and loading states
--->
 
 ### Project Setup & Configuration - 2025-12-31
 

--- a/src/api/tickets.ts
+++ b/src/api/tickets.ts
@@ -43,3 +43,35 @@ export async function createTicket(
 
   return response.data as Ticket;
 }
+
+export async function scheduleTicket(ticketId: string, scheduledDate: string, signal?: AbortSignal): Promise<Ticket> {
+  const response = await apiClient.patch(
+    `/tickets/${ticketId}`,
+    {
+      scheduled_date: scheduledDate,
+    },
+    { signal },
+  );
+
+  if (response.status !== 200) {
+    throw new Error(`Failed to schedule ticket: ${response.status}`);
+  }
+
+  return response.data as Ticket;
+}
+
+export async function unscheduleTicket(ticketId: string, signal?: AbortSignal): Promise<Ticket> {
+  const response = await apiClient.patch(
+    `/tickets/${ticketId}`,
+    {
+      scheduled_date: null,
+    },
+    { signal },
+  );
+
+  if (response.status !== 200) {
+    throw new Error(`Failed to unschedule ticket: ${response.status}`);
+  }
+
+  return response.data as Ticket;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import { WebSocketProvider } from "@/lib/websocket-provider";
+import "@/styles/themes.css";
 import LegacyRootLayout, { metadata as legacyMetadata, viewport as legacyViewport } from "../old/app/layout";
 
 export const metadata: Metadata = legacyMetadata;

--- a/src/components/calendar/CalendarEvent.tsx
+++ b/src/components/calendar/CalendarEvent.tsx
@@ -18,9 +18,18 @@ export function CalendarEvent({ eventInfo }: CalendarEventProps) {
   const isEventShort = isShortEvent(event.start, event.end);
 
   // Visual properties
-  const bandColor = extendedProps?.bandColor || "#3b82f6";
+  const bandColor = extendedProps?.bandColor || "var(--accent)";
   const showBand = extendedProps?.showBand !== false;
   const isCompleted = extendedProps?.ticket_status === "Done" || extendedProps?.ticket_status === "Removed" || extendedProps?.completed === true;
+
+  // All-day events: render as a compact header-only chip
+  if (event.allDay) {
+    return (
+      <div className="relative flex h-full items-center overflow-hidden px-1.5 py-0.5">
+        <div className="truncate text-[11px] font-semibold leading-tight sm:text-xs">{event.title}</div>
+      </div>
+    );
+  }
 
   // Compact layout for short events (< 30 min) - better for mobile
   if (isEventShort) {
@@ -40,8 +49,8 @@ export function CalendarEvent({ eventInfo }: CalendarEventProps) {
                 45deg,
                 transparent,
                 transparent 4px,
-                #6b7280 4px,
-                #6b7280 5.5px
+                var(--event-completed-stripe) 4px,
+                var(--event-completed-stripe) 5.5px
               )`,
             }}
           />
@@ -71,8 +80,8 @@ export function CalendarEvent({ eventInfo }: CalendarEventProps) {
               45deg,
               transparent,
               transparent 4px,
-              #6b7280 4px,
-              #6b7280 5.5px
+              var(--event-completed-stripe) 4px,
+              var(--event-completed-stripe) 5.5px
             )`,
           }}
         />

--- a/src/components/calendar/CalendarHeader.tsx
+++ b/src/components/calendar/CalendarHeader.tsx
@@ -11,48 +11,68 @@ interface CalendarHeaderProps {
   onNext: () => void;
   onToday: () => void;
   onDateSelect?: () => void;
+  /**
+   * Whether the current calendar view includes today's date.
+   * When false, the Today button is rendered in a neutral style.
+   */
+  isTodayInRange?: boolean;
 }
 
 /**
  * Calendar Header with navigation controls
  * Matches old implementation design with date badge
  */
-export function CalendarHeader({ title, currentDate, onPrevious, onNext, onToday }: CalendarHeaderProps) {
+export function CalendarHeader({ title, currentDate, onPrevious, onNext, onToday, isTodayInRange = true }: CalendarHeaderProps) {
   const month = currentDate.toLocaleString("en-US", { month: "long" });
   const monthShort = currentDate.toLocaleString("en-US", { month: "short" }).toUpperCase();
   const day = currentDate.getDate();
   const wk = weekOfMonth(currentDate);
 
+  const todayButtonClasses = isTodayInRange
+    ? "h-9 rounded-full bg-[var(--accent)] px-4 text-sm font-semibold text-[var(--text-on-accent)] shadow-sm hover:bg-[var(--accent)] hover:text-[var(--text-on-accent)]"
+    : "h-9 rounded-full bg-[var(--accent-subtle)] px-4 text-sm font-semibold text-[var(--accent)] hover:bg-[var(--accent-soft)] hover:text-[var(--accent)]";
+
   return (
     <div className="flex items-center justify-between p-3 lg:p-4">
       <div className="flex items-center gap-3 lg:gap-4">
         {/* Date badge */}
-        <div className="flex h-16 w-16 flex-col items-center justify-center rounded-2xl border border-gray-200 bg-white shadow-sm lg:h-16 lg:w-16">
-          <div className="text-[10px] font-medium uppercase tracking-wide text-gray-500">{monthShort}</div>
-          <div className="text-2xl font-semibold leading-none text-gray-900">{day}</div>
+        <div className="flex h-16 w-16 flex-col items-center justify-center rounded-2xl border border-[var(--accent-soft)] bg-[var(--surface-elevated)] shadow-sm lg:h-16 lg:w-16">
+          <div className="text-[10px] font-medium uppercase tracking-wide text-[var(--accent)]">{monthShort}</div>
+          <div className="text-2xl font-semibold leading-none text-[var(--text)]">{day}</div>
+          <div className="mt-1 h-1.5 w-8 rounded-full bg-[var(--accent)]" />
         </div>
 
         {/* Title */}
         <div className="flex flex-col gap-0.5">
           <div className="flex items-center gap-2">
-            <span className="text-base font-semibold text-gray-900 lg:text-2xl">{month}</span>
-            <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-700">Week {wk}</span>
+            <span className="text-base font-semibold text-[var(--text)] lg:text-2xl">{month}</span>
+            <span className="rounded-full bg-[var(--accent-soft)] px-2 py-0.5 text-xs font-medium text-[var(--accent)]">Week {wk}</span>
           </div>
-          <div className="text-xs text-gray-500">{title}</div>
+          <div className="text-xs text-[var(--text-muted)]">{title}</div>
         </div>
       </div>
 
       {/* Navigation Controls */}
-      <div className="flex items-center rounded-lg border border-gray-200 text-gray-900 shadow-sm">
-        <Button variant="ghost" className="h-9 rounded-l-lg rounded-r-none border-0 px-3 hover:bg-gray-50" onClick={onPrevious} aria-label="Previous period">
+      <div className="flex items-center gap-2 rounded-full border border-[var(--accent-soft)] bg-[var(--accent-subtle)] px-2 py-1">
+        <Button
+          variant="ghost"
+          className="h-8 w-8 rounded-full border-0 px-0 text-[var(--accent)] hover:bg-[var(--accent-soft)]"
+          onClick={onPrevious}
+          aria-label="Previous period"
+        >
           <ChevronLeft className="h-4 w-4" />
         </Button>
 
-        <Button variant="ghost" className="h-9 rounded-none border-x border-gray-200 px-3 font-semibold hover:bg-gray-50" onClick={onToday}>
+        <Button variant="ghost" className={todayButtonClasses} onClick={onToday}>
           Today
         </Button>
 
-        <Button variant="ghost" className="h-9 rounded-l-none rounded-r-lg border-0 px-3 hover:bg-gray-50" onClick={onNext} aria-label="Next period">
+        <Button
+          variant="ghost"
+          className="h-8 w-8 rounded-full border-0 px-0 text-[var(--accent)] hover:bg-[var(--accent-soft)]"
+          onClick={onNext}
+          aria-label="Next period"
+        >
           <ChevronRight className="h-4 w-4" />
         </Button>
       </div>

--- a/src/components/calendar/CalendarView.tsx
+++ b/src/components/calendar/CalendarView.tsx
@@ -123,18 +123,17 @@ export function CalendarView({
         stickyHeaderDates={config.stickyHeaderDates}
         firstDay={1} // Monday
         // Mobile-friendly day header
-        dayHeaderFormat={{ weekday: "short", day: "numeric", month: "numeric" }}
+        dayHeaderFormat={{ weekday: "short", day: "numeric" }}
         dayHeaderContent={(args) => {
           const date = args.date;
           const day = date.getDate();
-          const month = date.getMonth() + 1;
           const weekday = date.toLocaleDateString("en-US", { weekday: "short" });
 
-          // Format: Mon, 29/12
+          // Format: Mon 29
           return (
-            <div className="flex items-center gap-1 text-sm text-gray-900">
-              <span className="font-medium">{weekday},</span>
-              <span className="text-gray-600">{`${day}/${month}`}</span>
+            <div className="flex items-center gap-1 text-sm text-[var(--text)]">
+              <span className="font-medium">{weekday}</span>
+              <span className="text-[var(--text-muted)]">{day}</span>
             </div>
           );
         }}
@@ -177,6 +176,8 @@ export function CalendarView({
         }}
         // Time slots
         allDaySlot={config.allDaySlot}
+        // Use a clear text label for the all-day row
+        allDayText=""
         slotDuration={config.slotDuration}
         snapDuration="00:05:00"
         slotMinTime={config.slotMinTime}

--- a/src/components/modals/TicketCreateModal.tsx
+++ b/src/components/modals/TicketCreateModal.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+import React from "react";
+import { CalendarDays, ChevronDown, Feather } from "lucide-react";
+import { createTicket } from "@/api/tickets";
+import { CalendarCard } from "@/components/calendar/CalendarCard";
+import { cn } from "@/lib/utils";
+import type { Project } from "@/types/project";
+import type { Ticket, TicketType } from "@/types/ticket";
+import { Button } from "@/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogPortal, DialogTitle } from "@/ui/dialog";
+import { getAnchoredPopoverPosition } from "@/utils/calendar-popover-position";
+
+interface TicketCreateModalProps {
+  open: boolean;
+  projects: Project[];
+  selectedProjectKey?: string;
+  onClose: () => void;
+  onCreateTicket?: (ticket: Ticket, projectKey: string) => void;
+}
+
+export function TicketCreateModal({ open, projects, selectedProjectKey, onClose, onCreateTicket }: TicketCreateModalProps) {
+  const [newTicketTitle, setNewTicketTitle] = React.useState("");
+  const [isCreatingTicket, setIsCreatingTicket] = React.useState(false);
+  const [newTicketType, setNewTicketType] = React.useState<TicketType>("task");
+  const [newTicketProjectKey, setNewTicketProjectKey] = React.useState<string | undefined>(selectedProjectKey);
+  const [newTicketScheduledDate, setNewTicketScheduledDate] = React.useState<string | null>(null);
+  const [showCalendarPicker, setShowCalendarPicker] = React.useState(false);
+  const [calendarPickerPosition, setCalendarPickerPosition] = React.useState<{ x: number; y: number }>({ x: 0, y: 0 });
+
+  // Reset / initialize state when modal opens
+  React.useEffect(() => {
+    if (!open) return;
+    setNewTicketTitle("");
+    setNewTicketType("task");
+    setNewTicketScheduledDate(null);
+    setShowCalendarPicker(false);
+    setNewTicketProjectKey(selectedProjectKey ?? projects[0]?.project_key);
+  }, [open, selectedProjectKey, projects]);
+
+  const handleClose = () => {
+    setShowCalendarPicker(false);
+    onClose();
+  };
+
+  const handleCreateTicketClick = async () => {
+    if (!onCreateTicket || !newTicketTitle.trim()) return;
+
+    const projectKey = newTicketProjectKey ?? selectedProjectKey;
+    if (!projectKey) return;
+
+    const project = projects.find((p) => p.project_key === projectKey);
+    if (!project) {
+      console.error("Selected project not found for ticket creation", selectedProjectKey);
+      return;
+    }
+
+    try {
+      setIsCreatingTicket(true);
+      const created = await createTicket(
+        {
+          title: newTicketTitle.trim(),
+          projectNotionId: project.notion_id,
+          internalProjectId: project.project_id,
+          type: newTicketType,
+          scheduledDate: newTicketScheduledDate ?? undefined,
+        },
+        undefined,
+      );
+
+      onCreateTicket(created, project.project_key);
+      setNewTicketTitle("");
+      setNewTicketType("task");
+      setNewTicketScheduledDate(null);
+      setShowCalendarPicker(false);
+      handleClose();
+    } catch (error) {
+      console.error("Failed to create ticket", error);
+      // Simple fallback UX for now
+      alert("Failed to create ticket. Please try again.");
+    } finally {
+      setIsCreatingTicket(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(nextOpen) => (nextOpen ? undefined : handleClose())}>
+      <DialogContent
+        className="max-w-md rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)] p-6 shadow-xl sm:max-w-lg sm:p-8"
+        onInteractOutside={(event) => {
+          event.preventDefault();
+        }}
+      >
+        <DialogHeader className="mb-4">
+          <DialogTitle className="text-lg font-semibold text-[var(--text)]">Ticket Title</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-5">
+          <div>
+            <input
+              type="text"
+              value={newTicketTitle}
+              onChange={(e) => setNewTicketTitle(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  void handleCreateTicketClick();
+                }
+              }}
+              placeholder="Enter ticket title..."
+              autoFocus
+              className="w-full rounded-xl border border-[var(--accent)] bg-[var(--surface)] px-3 py-2 text-sm text-[var(--text)] shadow-[0_0_0_1px_var(--accent-soft)] placeholder:text-[var(--text-muted)] focus:border-[var(--accent)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-soft)]"
+            />
+          </div>
+
+          <div className="flex items-center justify-between gap-3 text-xs text-[var(--text-muted)]">
+            {/* Project dropdown */}
+            <div className="flex items-center gap-1.5">
+              <Feather className="h-3.5 w-3.5 text-[var(--text-muted)]" />
+              <div className="relative">
+                <select
+                  value={newTicketProjectKey}
+                  onChange={(e) => setNewTicketProjectKey(e.target.value)}
+                  className="w-[160px] cursor-pointer appearance-none rounded-full border border-[var(--border-subtle)] bg-[var(--surface)] px-3 py-1 pr-7 text-[11px] font-medium text-[var(--text)] shadow-sm outline-none hover:border-[var(--accent-soft)] hover:bg-[var(--accent-subtle)] sm:w-[220px]"
+                >
+                  {projects.map((project) => (
+                    <option key={project.project_key} value={project.project_key}>
+                      {project.title}
+                    </option>
+                  ))}
+                </select>
+                <ChevronDown className="pointer-events-none absolute right-2 top-1/2 h-3 w-3 -translate-y-1/2 text-[var(--text-muted)]" />
+              </div>
+            </div>
+
+            {/* Type + calendar controls */}
+            <div className="flex items-center gap-3">
+              <div className="flex items-center gap-1.5">
+                <div className="relative">
+                  <select
+                    value={newTicketType}
+                    onChange={(e) => setNewTicketType(e.target.value as TicketType)}
+                    className="w-[90px] cursor-pointer appearance-none rounded-full border border-[var(--accent-soft)] bg-[var(--accent-subtle)] px-2 py-0.5 pr-6 text-center text-[11px] font-medium text-[var(--accent)] outline-none hover:bg-[var(--accent-soft)]"
+                  >
+                    <option value="task">Task</option>
+                    <option value="story">Story</option>
+                    <option value="bug">Bug</option>
+                    <option value="event">Event</option>
+                  </select>
+                  <ChevronDown className="pointer-events-none absolute right-1.5 top-1/2 h-3 w-3 -translate-y-1/2 text-[var(--accent)]" />
+                </div>
+              </div>
+
+              <div className="flex items-center gap-2">
+                {newTicketScheduledDate && newTicketType !== "event" && (
+                  <button
+                    type="button"
+                    onClick={() => setNewTicketScheduledDate(null)}
+                    className="hover:text-[var(--accent)]/90 flex cursor-pointer items-center gap-1 text-[11px] font-medium text-[var(--accent)]"
+                  >
+                    <span>
+                      {new Date(newTicketScheduledDate).toLocaleDateString("en-US", {
+                        month: "short",
+                        day: "numeric",
+                      })}
+                    </span>
+                    <span className="text-[10px] text-[var(--text-muted)]">×</span>
+                  </button>
+                )}
+
+                {newTicketType !== "event" && (
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+
+                      if (showCalendarPicker) {
+                        setShowCalendarPicker(false);
+                      } else {
+                        const rect = e.currentTarget.getBoundingClientRect();
+                        const { x, y } = getAnchoredPopoverPosition(rect, 288, 320);
+
+                        setCalendarPickerPosition({ x, y });
+                        setShowCalendarPicker(true);
+                      }
+                    }}
+                    className={cn(
+                      "flex h-8 w-8 cursor-pointer items-center justify-center rounded-lg border border-[var(--accent-soft)] text-[var(--accent)] shadow-sm",
+                      showCalendarPicker || newTicketScheduledDate ? "bg-[var(--accent-soft)]" : "bg-[var(--surface)] hover:bg-[var(--accent-subtle)]",
+                    )}
+                  >
+                    <CalendarDays className="h-4 w-4" />
+                  </button>
+                )}
+              </div>
+            </div>
+          </div>
+
+          <div className="pt-1">
+            <Button
+              className="hover:bg-[var(--accent)]/90 mb-4 h-11 w-full cursor-pointer justify-center rounded-xl bg-[var(--accent)] text-sm font-semibold text-[var(--text-on-accent)]"
+              disabled={isCreatingTicket || !newTicketTitle.trim()}
+              onClick={handleCreateTicketClick}
+            >
+              {isCreatingTicket ? "Creating..." : "Create Ticket"}
+            </Button>
+
+            <div className="flex items-center justify-center gap-3 pb-3 text-[11px] font-medium uppercase tracking-wide text-gray-400">
+              <span className="h-px w-10 bg-[var(--border-subtle)] sm:w-16" />
+              <span>or</span>
+              <span className="h-px w-10 bg-[var(--border-subtle)] sm:w-16" />
+            </div>
+
+            <Button
+              type="button"
+              variant="outline"
+              className="h-11 w-full justify-center rounded-xl border-[var(--border-subtle)] text-sm font-medium text-[var(--text-muted)] hover:bg-[var(--accent-subtle)]"
+              // TODO: Implement create-from-image flow
+              disabled
+            >
+              Create from Image
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+      {showCalendarPicker && newTicketType !== "event" && (
+        <DialogPortal>
+          <div
+            className="fixed"
+            style={{ left: `${calendarPickerPosition.x}px`, top: `${calendarPickerPosition.y}px`, zIndex: 60, pointerEvents: "auto" }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <CalendarCard
+              initialDate={newTicketScheduledDate ? new Date(newTicketScheduledDate) : new Date()}
+              minDate={new Date()}
+              onSelect={(date: Date) => {
+                const year = date.getFullYear();
+                const month = String(date.getMonth() + 1).padStart(2, "0");
+                const day = String(date.getDate()).padStart(2, "0");
+                const selectedDate = `${year}-${month}-${day}`;
+                setNewTicketScheduledDate(selectedDate);
+                setShowCalendarPicker(false);
+              }}
+            />
+          </div>
+        </DialogPortal>
+      )}
+    </Dialog>
+  );
+}

--- a/src/components/planner/PlannerLayout.tsx
+++ b/src/components/planner/PlannerLayout.tsx
@@ -2,9 +2,10 @@
 
 import { ReactNode, useCallback, useEffect, useRef, useState } from "react";
 import { Feather } from "lucide-react";
+import { PlannerNavBar } from "@/components/planner/PlannerNavBar";
 import { useIsMobile } from "@/hooks/useIsMobile";
+import { usePlannerTheme } from "@/hooks/usePlannerTheme";
 import { cn } from "@/lib/utils";
-import { Button } from "@/ui/button";
 
 interface PlannerLayoutProps {
   sidebar: ReactNode;
@@ -22,8 +23,11 @@ const OPEN_HEIGHT_VH = 50; // Default open height (1/2 of screen)
  * Desktop: Side-by-side with collapsible sidebar
  */
 export function PlannerLayout({ sidebar, calendar, navigation }: PlannerLayoutProps) {
+  const { theme, containerClass, setTheme } = usePlannerTheme();
+
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [desktopSidebarCollapsed, setDesktopSidebarCollapsed] = useState(false);
+  const [activePanelId, setActivePanelId] = useState<string | null>("tickets");
   const [drawerHeight, setDrawerHeight] = useState(CLOSED_HEIGHT);
   const [isDragging, setIsDragging] = useState(false);
   const isMobile = useIsMobile();
@@ -117,17 +121,32 @@ export function PlannerLayout({ sidebar, calendar, navigation }: PlannerLayoutPr
     }
   }, [isDragging, handleDragMove, handleDragEnd]);
 
+  const isDark = theme === "soft-dark";
+
   return (
-    <div className="flex h-full w-full flex-col">
-      {/* Navigation placeholder */}
-      {navigation}
+    <div className={cn(containerClass, "flex h-full w-full flex-col bg-[var(--planner-bg)]")}>
+      {/* Optional top navigation bar; omit entirely when no navigation is provided */}
+      {navigation && (
+        <div className="flex items-center justify-between px-3 pb-2 pt-2 sm:px-4 sm:pt-3">
+          <div className="min-w-0 flex-1">{navigation}</div>
+        </div>
+      )}
 
       {/* Main content area */}
       <div className="relative flex flex-1 overflow-hidden">
         {/* Calendar - shrinks when sidebar expands */}
         <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
           {/* Calendar takes full height, with bottom padding equal to drawer height on mobile so content isn't hidden behind the tickets drawer */}
-          <div className="flex-1 overflow-hidden" style={{ paddingBottom: isMobile ? (sidebarOpen || isDragging ? drawerHeight : CLOSED_HEIGHT) : 0 }}>
+          <div
+            className="flex-1 overflow-hidden bg-[var(--planner-surface)] shadow-[var(--planner-card-shadow)] lg:mx-4 lg:mt-3"
+            style={{
+              // On mobile, keep the calendar flush with the viewport edges
+              // (no rounding). On desktop, round only the top corners so the
+              // bottom edge lines up cleanly against the drawer/sidebar.
+              borderRadius: isMobile ? 0 : "var(--planner-surface-radius) var(--planner-surface-radius) 0 0",
+              paddingBottom: isMobile ? (sidebarOpen || isDragging ? drawerHeight : CLOSED_HEIGHT) : 0,
+            }}
+          >
             {calendar}
           </div>
 
@@ -136,71 +155,85 @@ export function PlannerLayout({ sidebar, calendar, navigation }: PlannerLayoutPr
             {/* Drawer container */}
             <div
               className={cn(
-                "fixed inset-x-0 bottom-0 z-50 flex flex-col bg-white shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.1)]",
+                "fixed inset-x-0 bottom-0 z-50 flex flex-col overflow-hidden border-t border-[var(--border-subtle)] bg-[var(--planner-sidebar-surface,var(--planner-sidebar-bg))] shadow-[0_-4px_18px_rgba(15,23,42,0.18)]",
                 !isDragging && "transition-all duration-300 ease-in-out",
               )}
               style={{ height: `${drawerHeight}px` }}
             >
-              {/* Toggle/drag bar - always visible */}
-              <div
-                className="flex h-10 w-full cursor-grab items-center justify-center bg-white active:cursor-grabbing"
-                style={{ touchAction: "none" }}
-                onMouseDown={handleMouseDown}
-                onTouchStart={handleTouchStart}
-                onClick={() => {
-                  // Only toggle if not dragging
-                  if (!isDragging) {
-                    if (sidebarOpen) {
-                      setSidebarOpen(false);
-                      setDrawerHeight(CLOSED_HEIGHT);
-                    } else {
-                      const vh = window.innerHeight / 100;
-                      const openHeightPx = OPEN_HEIGHT_VH * vh;
-                      setSidebarOpen(true);
-                      setDrawerHeight(openHeightPx);
+              <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(37,99,235,0.14),transparent_45%)]" />
+              <div className="relative z-10 flex h-full flex-col">
+                {/* Toggle/drag bar - always visible */}
+                <div
+                  className="flex h-10 w-full cursor-grab items-center justify-center active:cursor-grabbing"
+                  style={{ touchAction: "none" }}
+                  onMouseDown={handleMouseDown}
+                  onTouchStart={handleTouchStart}
+                  onClick={() => {
+                    // Only toggle if not dragging
+                    if (!isDragging) {
+                      if (sidebarOpen) {
+                        setSidebarOpen(false);
+                        setDrawerHeight(CLOSED_HEIGHT);
+                      } else {
+                        const vh = window.innerHeight / 100;
+                        const openHeightPx = OPEN_HEIGHT_VH * vh;
+                        setSidebarOpen(true);
+                        setDrawerHeight(openHeightPx);
+                      }
                     }
-                  }
-                }}
-              >
-                <div className="flex flex-col items-center">
-                  {/* Drag handle indicator */}
-                  <div className="h-1 w-12 rounded-full bg-gray-300" />
+                  }}
+                >
+                  <div className="flex flex-col items-center">
+                    {/* Drag handle indicator */}
+                    <div className="h-1 w-12 rounded-full bg-[var(--border-strong)]" />
+                  </div>
                 </div>
-              </div>
 
-              {/* Drawer content */}
-              <div className="flex-1 overflow-hidden">{sidebar}</div>
+                {/* Drawer content */}
+                <div className="flex-1 overflow-hidden">{sidebar}</div>
+              </div>
             </div>
           </div>
         </div>
 
         {/* Desktop: Side-by-side sidebar */}
         <div className="relative hidden lg:flex">
-          {/* Expanded sidebar content */}
+          {/* Expanded side panel area driven by nav bar selection */}
           <div
             className={cn(
-              "flex flex-col border-l border-gray-200 bg-white transition-all duration-150",
-              desktopSidebarCollapsed ? "w-0 overflow-hidden opacity-0" : "xl:w-70 w-60 opacity-100",
+              "relative flex flex-col overflow-hidden border-l border-[var(--border-subtle)] bg-[var(--planner-sidebar-surface,var(--planner-sidebar-bg))] transition-all duration-150",
+              desktopSidebarCollapsed || !activePanelId ? "w-0 overflow-hidden opacity-0" : "xl:w-70 w-60 opacity-100",
             )}
           >
-            {!desktopSidebarCollapsed && <div className="flex-1 overflow-hidden">{sidebar}</div>}
+            <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(37,99,235,0.16),transparent_35%)]" />
+            <div className="relative z-10 flex h-full flex-col">
+              {!desktopSidebarCollapsed && activePanelId === "tickets" && <div className="flex-1 overflow-hidden">{sidebar}</div>}
+            </div>
           </div>
 
-          {/* Collapsed thin sidebar with icons - stays on right */}
-          <div className={cn("flex w-12 flex-col items-center bg-white py-4", desktopSidebarCollapsed && "border-l border-gray-200")}>
-            <Button
-              variant="ghost"
-              size="icon"
-              className={cn(
-                "h-10 w-10 rounded-lg transition-colors",
-                !desktopSidebarCollapsed ? "bg-violet-50 text-violet-700" : "text-gray-600 hover:bg-gray-100",
-              )}
-              onClick={() => setDesktopSidebarCollapsed(!desktopSidebarCollapsed)}
-              aria-label="Toggle tickets sidebar"
-            >
-              <Feather className="h-5 w-5" />
-            </Button>
-          </div>
+          {/* Nav bar anchored to the right */}
+          <PlannerNavBar
+            items={[
+              {
+                id: "tickets",
+                icon: <Feather className="h-5 w-5" />,
+                label: "Project tickets",
+              },
+            ]}
+            activeId={!desktopSidebarCollapsed ? activePanelId : null}
+            onSelect={(id) => {
+              // Toggle behaviour: clicking the active id collapses; otherwise switch panel and expand.
+              if (!desktopSidebarCollapsed && activePanelId === id) {
+                setDesktopSidebarCollapsed(true);
+                return;
+              }
+
+              setActivePanelId(id);
+              setDesktopSidebarCollapsed(false);
+            }}
+            isDark={isDark}
+            onToggleTheme={() => setTheme(isDark ? "soft-light" : "soft-dark")}
+          />
         </div>
       </div>
     </div>

--- a/src/components/planner/PlannerNavBar.tsx
+++ b/src/components/planner/PlannerNavBar.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { MoonStar, SunMedium } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/ui/button";
+
+export interface PlannerNavBarItem {
+  id: string;
+  icon: ReactNode;
+  label: string;
+}
+
+interface PlannerNavBarProps {
+  items: PlannerNavBarItem[];
+  /** The id of the currently active/open panel, or null when none are open. */
+  activeId: string | null;
+  /** Called when a nav item is clicked. */
+  onSelect: (id: string) => void;
+  /** Whether the planner is currently using the dark theme. */
+  isDark: boolean;
+  /** Toggle between light and dark themes. */
+  onToggleTheme: () => void;
+}
+
+/**
+ * Vertical planner navigation bar anchored to the right-hand side.
+ *
+ * - Top: primary action buttons (e.g. tickets, future panels)
+ * - Bottom: theme toggle (soft light/dark)
+ *
+ * The nav itself does not manage which drawer is open; it simply exposes
+ * selection events so the layout can show/hide the appropriate panel.
+ */
+export function PlannerNavBar({ items, activeId, onSelect, isDark, onToggleTheme }: PlannerNavBarProps) {
+  return (
+    <div className={cn("flex w-12 flex-col items-center border-l border-[var(--border-subtle)] bg-[var(--planner-sidebar-bg)] py-4")}>
+      <div className="flex flex-1 flex-col items-center gap-2">
+        {items.map((item) => {
+          const isActive = item.id === activeId;
+
+          return (
+            <Button
+              key={item.id}
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label={item.label}
+              className={cn(
+                "h-10 w-10 rounded-lg transition-colors",
+                isActive
+                  ? "bg-[var(--accent-soft)] text-[var(--accent)]"
+                  : "text-[var(--text-muted)] hover:bg-[var(--accent-subtle)] hover:text-[var(--accent)]",
+              )}
+              onClick={() => onSelect(item.id)}
+            >
+              {item.icon}
+            </Button>
+          );
+        })}
+      </div>
+
+      {/* Theme toggle pinned to bottom */}
+      <div className="mt-4 flex flex-col items-center">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label={isDark ? "Switch to light theme" : "Switch to dark theme"}
+          className={cn(
+            "h-10 w-10 rounded-lg transition-colors",
+            isDark ? "bg-[var(--accent-soft)] text-[var(--accent)]" : "text-[var(--text-muted)] hover:bg-[var(--accent-subtle)] hover:text-[var(--accent)]",
+          )}
+          onClick={onToggleTheme}
+        >
+          {isDark ? <SunMedium className="h-4 w-4" /> : <MoonStar className="h-4 w-4" />}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/planner/TicketCard.tsx
+++ b/src/components/planner/TicketCard.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import React from "react";
+import { AlertCircle, BookOpen, CalendarDays, CalendarMinus, CalendarPlus, Check, CheckSquare, Diamond, Video } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { Ticket, TicketType } from "@/types/ticket";
+import { Badge } from "@/ui/badge";
+import { Card } from "@/ui/card";
+import { getAnchoredPopoverPosition } from "@/utils/calendar-popover-position";
+
+interface TicketCardProps {
+  ticket: Ticket;
+  isDone: boolean;
+  isEventToday: boolean;
+  onTicketClick: (ticket: Ticket) => void;
+  onUnscheduleTicket?: (ticketId: string) => void;
+  onOpenSchedulePicker?: (ticketId: string, position: { x: number; y: number }) => void;
+  eventTimeRange?: string | null;
+}
+
+function statusPillClasses(status: string) {
+  if (status === "In Progress" || status === "In Review") return "bg-[var(--accent-soft)] text-[var(--accent)]";
+  if (status === "Todo" || status === "Backlog") return "bg-[var(--surface-muted)] text-[var(--text-muted)]";
+  if (status === "Blocked") return "border border-[var(--danger)] bg-transparent text-[var(--danger)]";
+  if (status === "Done") return "border border-[var(--success)] bg-transparent text-[var(--success)]";
+  return "bg-[var(--surface-muted)] text-[var(--text-muted)]";
+}
+
+function ticketTypeIcon(type: TicketType, isDone: boolean) {
+  const base = "h-3 w-3";
+  if (isDone) return <Check className={`${base} text-[var(--success)]`} />;
+
+  switch (type.toLowerCase()) {
+    case "bug":
+      return <AlertCircle className={`${base} text-[var(--danger)]`} />;
+    case "story":
+      return <BookOpen className={`${base} text-[var(--success)]`} />;
+    case "epic":
+      return <Diamond className={`${base} text-[var(--accent)]`} />;
+    case "subtask":
+      return <CheckSquare className={`${base} text-[var(--accent)]`} />;
+    case "event":
+      return <CalendarDays className={`${base} text-[var(--text-muted)]`} />;
+    default:
+      return <CheckSquare className={`${base} text-[var(--accent)]`} />;
+  }
+}
+
+function ticketTypeStripClasses(type: TicketType, isDone: boolean) {
+  if (isDone) return "bg-[var(--surface-muted)] text-[var(--text-muted)]";
+
+  switch (type.toLowerCase()) {
+    case "bug":
+      return "bg-red-50 text-[var(--danger)]";
+    case "story":
+      return "bg-emerald-50 text-[var(--success)]";
+    case "epic":
+      return "bg-indigo-50 text-[var(--accent)]";
+    case "subtask":
+      return "bg-sky-50 text-[var(--accent)]";
+    case "event":
+      return "bg-slate-50 text-[var(--text-muted)]";
+    default:
+      return "bg-[var(--accent-subtle)] text-[var(--accent)]";
+  }
+}
+
+function meetingPlatformLabel(platform?: Ticket["meeting_platform"]): string {
+  switch (platform) {
+    case "google_meet":
+      return "Meet";
+    case "zoom":
+      return "Zoom";
+    case "teams":
+      return "Teams";
+    case "other":
+      return "Call";
+    default:
+      return "Call";
+  }
+}
+
+export function TicketCard({ ticket, isDone, isEventToday, onTicketClick, onUnscheduleTicket, onOpenSchedulePicker, eventTimeRange }: TicketCardProps) {
+  const isEventTicket = ticket.ticket_type.toLowerCase() === "event";
+  const codeLength = ticket.ticket_key.length;
+  const codeTranslateY = codeLength * 7.5; // px offset to keep different lengths visually balanced
+
+  return (
+    <Card
+      key={ticket.ticket_id}
+      className={cn(
+        "relative rounded-xl border p-0",
+        isEventTicket ? "min-h-[64px]" : "min-h-[80px]",
+        !isEventToday && "draggable-ticket cursor-grab active:cursor-grabbing",
+        "touch-manipulation",
+        isEventToday
+          ? "border-[var(--border-subtle)] bg-[var(--surface)] shadow-none"
+          : isDone
+            ? "border-[var(--border-subtle)] bg-[var(--surface)] opacity-75 shadow-sm"
+            : "border-[var(--accent-subtle)] bg-[var(--surface-elevated)] shadow-sm hover:border-[var(--accent-soft)] hover:shadow-md",
+      )}
+      data-ticket-id={isEventToday ? undefined : ticket.ticket_id}
+      data-title={isEventToday ? undefined : ticket.title}
+      data-project-id={isEventToday ? undefined : ticket.project_id}
+      onClick={() => onTicketClick(ticket)}
+      style={{
+        willChange: "transform",
+        backfaceVisibility: "hidden",
+        transform: "translateZ(0)",
+      }}
+    >
+      {/* Subtle ticket watermark */}
+      <span aria-hidden="true" className="pointer-events-none absolute -right-3 -top-4 text-5xl opacity-[0.04]">
+        🎟️
+      </span>
+      <div className="flex h-full items-stretch">
+        {/* Left shaded strip with vertical icon + key */}
+        <div
+          className={cn(
+            "relative flex w-11 flex-col items-center justify-start overflow-hidden rounded-l-xl py-2 text-[9px] font-semibold uppercase tracking-[0.18em]",
+            ticketTypeStripClasses(ticket.ticket_type, isDone),
+          )}
+        >
+          {/* Icon row */}
+          <span className="flex h-5 w-5 items-center justify-center">{ticketTypeIcon(ticket.ticket_type, isDone)}</span>
+
+          {/* Rotated ticket code with dynamic translateY based on length */}
+          <span
+            className="pointer-events-none absolute whitespace-nowrap font-mono text-[10px] leading-none tracking-[0.25em]"
+            style={{ transform: `translate(0, ${codeTranslateY}px) rotate(90deg)` }}
+          >
+            {ticket.ticket_key}
+          </span>
+        </div>
+
+        {/* Main content */}
+        <div className="flex flex-1 flex-col p-3">
+          {/* Epic + status / meeting row */}
+          <div className="mb-2 flex items-start justify-between">
+            <div className="flex min-h-4 min-w-0 flex-shrink items-center gap-2">
+              {ticket.epic && (
+                <>
+                  <span className="flex h-4 w-4 flex-shrink-0 items-center justify-center">
+                    <Diamond className={cn("h-3 w-3", isDone ? "text-[var(--text-muted)]" : "text-[var(--accent)]")} />
+                  </span>
+                  <span className={cn("truncate text-xs", isDone ? "text-[var(--text-muted)]" : "text-[var(--text-muted)]")}>{ticket.epic}</span>
+                </>
+              )}
+            </div>
+
+            {isEventTicket && ticket.meeting_url ? (
+              <div className="flex items-center gap-1 rounded-full px-1.5 py-1 text-[11px] font-medium text-[var(--accent-meeting)]">
+                <Video className="h-3.5 w-3.5 text-[var(--accent-meeting)]" />
+                <span>{meetingPlatformLabel(ticket.meeting_platform)}</span>
+              </div>
+            ) : (
+              !isEventToday && (
+                <Badge className={cn("rounded-full px-2 py-0.5 text-xs font-semibold", statusPillClasses(ticket.ticket_status))}>{ticket.ticket_status}</Badge>
+              )
+            )}
+          </div>
+
+          {/* Ticket title */}
+          <p className={cn("mb-2 line-clamp-2 text-sm font-medium leading-tight", isDone ? "text-[var(--text-muted)] line-through" : "text-[var(--text)]")}>
+            {ticket.title}
+          </p>
+
+          {/* Tear line */}
+          <div className="mb-2 border-t border-dashed border-[var(--accent-soft)]" />
+
+          {/* Bottom row: event time range or schedule controls */}
+          <div className="mt-auto flex items-center justify-end gap-2">
+            {isEventToday && eventTimeRange ? (
+              <span className="text-xs font-medium text-[var(--accent)]">{eventTimeRange}</span>
+            ) : (
+              !isEventToday && (
+                <>
+                  {ticket.scheduled_date && !isDone && (
+                    <span className="flex-shrink-0 text-xs text-[var(--accent)]">
+                      {new Date(ticket.scheduled_date).toLocaleDateString("en-US", {
+                        month: "short",
+                        day: "numeric",
+                      })}
+                    </span>
+                  )}
+
+                  {!isDone && ticket.scheduled_date && onUnscheduleTicket && (
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        onUnscheduleTicket(ticket.ticket_id);
+                      }}
+                      className="flex h-6 w-6 cursor-pointer items-center justify-center rounded-md border border-[var(--danger)] bg-[var(--surface)] text-[var(--danger)] transition-colors hover:bg-[var(--accent-subtle)]"
+                    >
+                      <CalendarMinus className="h-3 w-3" />
+                    </button>
+                  )}
+
+                  {!isDone && onOpenSchedulePicker && (
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+
+                        const rect = (e.currentTarget as HTMLButtonElement).getBoundingClientRect();
+                        const { x, y } = getAnchoredPopoverPosition(rect, 288, 320);
+
+                        onOpenSchedulePicker(ticket.ticket_id, { x, y });
+                      }}
+                      className="flex h-6 w-6 cursor-pointer items-center justify-center rounded-md bg-[var(--accent-soft)] text-[var(--accent)] transition-colors hover:bg-[var(--accent-subtle)]"
+                    >
+                      <CalendarPlus className="h-3 w-3" />
+                    </button>
+                  )}
+                </>
+              )
+            )}
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/src/components/planner/TicketCreateModal.tsx
+++ b/src/components/planner/TicketCreateModal.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import React from "react";
+import { CalendarDays, ChevronDown, Feather } from "lucide-react";
+import { createTicket } from "@/api/tickets";
+import { CalendarCard } from "@/components/calendar/CalendarCard";
+import { cn } from "@/lib/utils";
+import type { Project } from "@/types/project";
+import type { Ticket, TicketType } from "@/types/ticket";
+import { Button } from "@/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogPortal, DialogTitle } from "@/ui/dialog";
+
+interface TicketCreateModalProps {
+  open: boolean;
+  projects: Project[];
+  selectedProjectKey?: string;
+  onClose: () => void;
+  onCreateTicket?: (ticket: Ticket, projectKey: string) => void;
+}
+
+export function TicketCreateModal({ open, projects, selectedProjectKey, onClose, onCreateTicket }: TicketCreateModalProps) {
+  const [newTicketTitle, setNewTicketTitle] = React.useState("");
+  const [isCreatingTicket, setIsCreatingTicket] = React.useState(false);
+  const [newTicketType, setNewTicketType] = React.useState<TicketType>("task");
+  const [newTicketProjectKey, setNewTicketProjectKey] = React.useState<string | undefined>(selectedProjectKey);
+  const [newTicketScheduledDate, setNewTicketScheduledDate] = React.useState<string | null>(null);
+  const [showCalendarPicker, setShowCalendarPicker] = React.useState(false);
+  const [calendarPickerPosition, setCalendarPickerPosition] = React.useState<{ x: number; y: number }>({ x: 0, y: 0 });
+
+  // Reset / initialize state when modal opens
+  React.useEffect(() => {
+    if (!open) return;
+    setNewTicketTitle("");
+    setNewTicketType("task");
+    setNewTicketScheduledDate(null);
+    setShowCalendarPicker(false);
+    setNewTicketProjectKey(selectedProjectKey ?? projects[0]?.project_key);
+  }, [open, selectedProjectKey, projects]);
+
+  const handleClose = () => {
+    setShowCalendarPicker(false);
+    onClose();
+  };
+
+  const handleCreateTicketClick = async () => {
+    if (!onCreateTicket || !newTicketTitle.trim()) return;
+
+    const projectKey = newTicketProjectKey ?? selectedProjectKey;
+    if (!projectKey) return;
+
+    const project = projects.find((p) => p.project_key === projectKey);
+    if (!project) {
+      console.error("Selected project not found for ticket creation", selectedProjectKey);
+      return;
+    }
+
+    try {
+      setIsCreatingTicket(true);
+      const created = await createTicket(
+        {
+          title: newTicketTitle.trim(),
+          projectNotionId: project.notion_id,
+          internalProjectId: project.project_id,
+          type: newTicketType,
+          scheduledDate: newTicketScheduledDate ?? undefined,
+        },
+        undefined,
+      );
+
+      onCreateTicket(created, project.project_key);
+      setNewTicketTitle("");
+      setNewTicketType("task");
+      setNewTicketScheduledDate(null);
+      setShowCalendarPicker(false);
+      handleClose();
+    } catch (error) {
+      console.error("Failed to create ticket", error);
+      // Simple fallback UX for now
+      alert("Failed to create ticket. Please try again.");
+    } finally {
+      setIsCreatingTicket(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(nextOpen) => (nextOpen ? undefined : handleClose())}>
+      <DialogContent
+        className="max-w-md rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)] p-6 shadow-xl sm:max-w-lg sm:p-8"
+        onInteractOutside={(event) => {
+          event.preventDefault();
+        }}
+      >
+        <DialogHeader className="mb-4">
+          <DialogTitle className="text-lg font-semibold text-[var(--text)]">Ticket Title</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-5">
+          <div>
+            <input
+              type="text"
+              value={newTicketTitle}
+              onChange={(e) => setNewTicketTitle(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  void handleCreateTicketClick();
+                }
+              }}
+              placeholder="Enter ticket title..."
+              autoFocus
+              className="w-full rounded-xl border border-[var(--accent)] bg-[var(--surface)] px-3 py-2 text-sm text-[var(--text)] shadow-[0_0_0_1px_var(--accent-soft)] placeholder:text-[var(--text-muted)] focus:border-[var(--accent)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-soft)]"
+            />
+          </div>
+
+          <div className="flex items-center justify-between gap-3 text-xs text-[var(--text-muted)]">
+            {/* Project dropdown */}
+            <div className="flex items-center gap-1.5">
+              <Feather className="h-3.5 w-3.5 text-[var(--text-muted)]" />
+              <div className="relative">
+                <select
+                  value={newTicketProjectKey}
+                  onChange={(e) => setNewTicketProjectKey(e.target.value)}
+                  className="w-[160px] cursor-pointer appearance-none rounded-full border border-[var(--border-subtle)] bg-[var(--surface)] px-3 py-1 pr-7 text-[11px] font-medium text-[var(--text)] shadow-sm outline-none hover:border-[var(--accent-soft)] hover:bg-[var(--accent-subtle)] sm:w-[220px]"
+                >
+                  {projects.map((project) => (
+                    <option key={project.project_key} value={project.project_key}>
+                      {project.title}
+                    </option>
+                  ))}
+                </select>
+                <ChevronDown className="pointer-events-none absolute right-2 top-1/2 h-3 w-3 -translate-y-1/2 text-[var(--text-muted)]" />
+              </div>
+            </div>
+
+            {/* Type + calendar controls */}
+            <div className="flex items-center gap-3">
+              <div className="flex items-center gap-1.5">
+                <div className="relative">
+                  <select
+                    value={newTicketType}
+                    onChange={(e) => setNewTicketType(e.target.value as TicketType)}
+                    className="w-[90px] cursor-pointer appearance-none rounded-full border border-[var(--accent-soft)] bg-[var(--accent-subtle)] px-2 py-0.5 pr-6 text-center text-[11px] font-medium text-[var(--accent)] outline-none hover:bg-[var(--accent-soft)]"
+                  >
+                    <option value="task">Task</option>
+                    <option value="story">Story</option>
+                    <option value="bug">Bug</option>
+                    <option value="event">Event</option>
+                  </select>
+                  <ChevronDown className="pointer-events-none absolute right-1.5 top-1/2 h-3 w-3 -translate-y-1/2 text-[var(--accent)]" />
+                </div>
+              </div>
+
+              <div className="flex items-center gap-2">
+                {newTicketScheduledDate && newTicketType !== "event" && (
+                  <button
+                    type="button"
+                    onClick={() => setNewTicketScheduledDate(null)}
+                    className="hover:text-[var(--accent)]/90 flex cursor-pointer items-center gap-1 text-[11px] font-medium text-[var(--accent)]"
+                  >
+                    <span>
+                      {new Date(newTicketScheduledDate).toLocaleDateString("en-US", {
+                        month: "short",
+                        day: "numeric",
+                      })}
+                    </span>
+                    <span className="text-[10px] text-[var(--text-muted)]">×</span>
+                  </button>
+                )}
+
+                {newTicketType !== "event" && (
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+
+                      if (showCalendarPicker) {
+                        setShowCalendarPicker(false);
+                      } else {
+                        const rect = e.currentTarget.getBoundingClientRect();
+                        const calendarWidth = 288;
+                        const calendarHeight = 320;
+
+                        let x = rect.right - calendarWidth;
+                        let y = rect.bottom + 4;
+
+                        if (x < 8) x = 8;
+                        if (x + calendarWidth > window.innerWidth - 8) {
+                          x = window.innerWidth - calendarWidth - 8;
+                        }
+                        if (y + calendarHeight > window.innerHeight - 8) {
+                          y = rect.top - calendarHeight - 4;
+                        }
+
+                        setCalendarPickerPosition({ x, y });
+                        setShowCalendarPicker(true);
+                      }
+                    }}
+                    className={cn(
+                      "flex h-8 w-8 cursor-pointer items-center justify-center rounded-lg border border-[var(--accent-soft)] text-[var(--accent)] shadow-sm",
+                      showCalendarPicker || newTicketScheduledDate ? "bg-[var(--accent-soft)]" : "bg-[var(--surface)] hover:bg-[var(--accent-subtle)]",
+                    )}
+                  >
+                    <CalendarDays className="h-4 w-4" />
+                  </button>
+                )}
+              </div>
+            </div>
+          </div>
+
+          <div className="pt-1">
+            <Button
+              className="hover:bg-[var(--accent)]/90 mb-4 h-11 w-full cursor-pointer justify-center rounded-xl bg-[var(--accent)] text-sm font-semibold text-[var(--text-on-accent)]"
+              disabled={isCreatingTicket || !newTicketTitle.trim()}
+              onClick={handleCreateTicketClick}
+            >
+              {isCreatingTicket ? "Creating..." : "Create Ticket"}
+            </Button>
+
+            <div className="flex items-center justify-center gap-3 pb-3 text-[11px] font-medium uppercase tracking-wide text-gray-400">
+              <span className="h-px w-10 bg-[var(--border-subtle)] sm:w-16" />
+              <span>or</span>
+              <span className="h-px w-10 bg-[var(--border-subtle)] sm:w-16" />
+            </div>
+
+            <Button
+              type="button"
+              variant="outline"
+              className="h-11 w-full justify-center rounded-xl border-[var(--border-subtle)] text-sm font-medium text-[var(--text-muted)] hover:bg-[var(--accent-subtle)]"
+              // TODO: Implement create-from-image flow
+              disabled
+            >
+              Create from Image
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+      {showCalendarPicker && newTicketType !== "event" && (
+        <DialogPortal>
+          <div
+            className="fixed"
+            style={{ left: `${calendarPickerPosition.x}px`, top: `${calendarPickerPosition.y}px`, zIndex: 60, pointerEvents: "auto" }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <CalendarCard
+              initialDate={newTicketScheduledDate ? new Date(newTicketScheduledDate) : new Date()}
+              minDate={new Date()}
+              onSelect={(date: Date) => {
+                const year = date.getFullYear();
+                const month = String(date.getMonth() + 1).padStart(2, "0");
+                const day = String(date.getDate()).padStart(2, "0");
+                const selectedDate = `${year}-${month}-${day}`;
+                setNewTicketScheduledDate(selectedDate);
+                setShowCalendarPicker(false);
+              }}
+            />
+          </div>
+        </DialogPortal>
+      )}
+    </Dialog>
+  );
+}

--- a/src/components/planner/TicketsSidebar.tsx
+++ b/src/components/planner/TicketsSidebar.tsx
@@ -2,31 +2,14 @@
 
 import React, { useEffect, useRef } from "react";
 import { Draggable } from "@fullcalendar/interaction";
-import {
-  AlertCircle,
-  Archive,
-  BookOpen,
-  CalendarDays,
-  CalendarMinus,
-  CalendarPlus,
-  Check,
-  CheckSquare,
-  ChevronDown,
-  Clock,
-  Diamond,
-  Feather,
-  Plus,
-} from "lucide-react";
-import { createTicket } from "@/api/tickets";
+import { Archive, CalendarDays, ChevronDown, Clock, Feather, Plus } from "lucide-react";
 import { CalendarCard } from "@/components/calendar/CalendarCard";
+import { TicketCreateModal } from "@/components/modals/TicketCreateModal";
+import { TicketCard } from "@/components/planner/TicketCard";
 import { cn } from "@/lib/utils";
 import type { CalendarEvent } from "@/types/calendar";
 import type { Project } from "@/types/project";
-import type { Ticket, TicketType } from "@/types/ticket";
-import { Badge } from "@/ui/badge";
-import { Button } from "@/ui/button";
-import { Card } from "@/ui/card";
-import { Dialog, DialogContent, DialogHeader, DialogPortal, DialogTitle } from "@/ui/dialog";
+import type { Ticket } from "@/types/ticket";
 import { ScrollArea } from "@/ui/scroll-area";
 
 interface TicketsSidebarProps {
@@ -44,34 +27,6 @@ interface TicketsSidebarProps {
 }
 
 type TabType = "today" | "unscheduled" | "backlog";
-
-function statusPillClasses(status: string) {
-  if (status === "In Progress" || status === "In Review") return "bg-indigo-50 text-indigo-700";
-  if (status === "Todo" || status === "Backlog") return "bg-gray-100 text-gray-700";
-  if (status === "Blocked") return "bg-amber-50 text-amber-700";
-  if (status === "Done") return "bg-emerald-50 text-emerald-700";
-  return "bg-gray-100 text-gray-700";
-}
-
-function ticketTypeIcon(type: TicketType, isDone: boolean) {
-  const base = "h-3 w-3";
-  if (isDone) return <Check className={`${base} text-emerald-600`} />;
-
-  switch (type.toLowerCase()) {
-    case "bug":
-      return <AlertCircle className={`${base} text-red-600`} />;
-    case "story":
-      return <BookOpen className={`${base} text-green-600`} />;
-    case "epic":
-      return <Diamond className={`${base} text-purple-600`} />;
-    case "subtask":
-      return <CheckSquare className={`${base} text-blue-600`} />;
-    case "event":
-      return <CalendarDays className={`${base} text-gray-600`} />;
-    default:
-      return <CheckSquare className={`${base} text-blue-600`} />;
-  }
-}
 
 /**
  * Sidebar component with draggable tickets list
@@ -93,13 +48,6 @@ export function TicketsSidebar({
   const ticketsListRef = useRef<HTMLDivElement>(null);
   const [activeTab, setActiveTab] = React.useState<TabType>("unscheduled");
   const [isCreateModalOpen, setIsCreateModalOpen] = React.useState(false);
-  const [newTicketTitle, setNewTicketTitle] = React.useState("");
-  const [isCreatingTicket, setIsCreatingTicket] = React.useState(false);
-  const [newTicketType, setNewTicketType] = React.useState<TicketType>("task");
-  const [newTicketProjectKey, setNewTicketProjectKey] = React.useState<string | undefined>(selectedProjectKey);
-  const [newTicketScheduledDate, setNewTicketScheduledDate] = React.useState<string | null>(null);
-  const [showCalendarPicker, setShowCalendarPicker] = React.useState(false);
-  const [calendarPickerPosition, setCalendarPickerPosition] = React.useState<{ x: number; y: number }>({ x: 0, y: 0 });
   const [ticketSchedulePicker, setTicketSchedulePicker] = React.useState<{ ticketId: string; x: number; y: number } | null>(null);
 
   // Initialize FullCalendar Draggable for ticket items
@@ -133,61 +81,8 @@ export function TicketsSidebar({
 
   const handleOpenCreateModal = () => {
     if (!selectedProjectKey && projects.length === 0) return;
-    setNewTicketTitle("");
-    setNewTicketType("task");
-    setNewTicketScheduledDate(null);
-    setShowCalendarPicker(false);
-    setNewTicketProjectKey(selectedProjectKey ?? projects[0]?.project_key);
     setIsCreateModalOpen(true);
     onUnselectCalendar?.();
-  };
-
-  const handleCloseCreateModal = () => {
-    setIsCreateModalOpen(false);
-    setNewTicketTitle("");
-    setNewTicketType("task");
-    setNewTicketScheduledDate(null);
-    setShowCalendarPicker(false);
-  };
-
-  const handleCreateTicketClick = async () => {
-    if (!onCreateTicket || !newTicketTitle.trim()) return;
-
-    const projectKey = newTicketProjectKey ?? selectedProjectKey;
-    if (!projectKey) return;
-
-    const project = projects.find((p) => p.project_key === projectKey);
-    if (!project) {
-      console.error("Selected project not found for ticket creation", selectedProjectKey);
-      return;
-    }
-
-    try {
-      setIsCreatingTicket(true);
-      const created = await createTicket(
-        {
-          title: newTicketTitle.trim(),
-          projectNotionId: project.notion_id,
-          internalProjectId: project.project_id,
-          type: newTicketType,
-          scheduledDate: newTicketScheduledDate ?? undefined,
-        },
-        undefined,
-      );
-
-      onCreateTicket(created, project.project_key);
-      setIsCreateModalOpen(false);
-      setNewTicketTitle("");
-      setNewTicketType("task");
-      setNewTicketScheduledDate(null);
-      onUnselectCalendar?.();
-    } catch (error) {
-      console.error("Failed to create ticket", error);
-      // Simple fallback UX for now
-      alert("Failed to create ticket. Please try again.");
-    } finally {
-      setIsCreatingTicket(false);
-    }
   };
 
   // Filter tickets based on active tab
@@ -287,16 +182,54 @@ export function TicketsSidebar({
     }
   }, [currentTickets, activeTab, selectedDay, events]);
 
+  const getEventTimeRangeForTicket = React.useCallback(
+    (ticketId: string): string | null => {
+      if (!events || events.length === 0) return null;
+
+      const day = selectedDay ? new Date(selectedDay) : new Date();
+      const dayStart = new Date(day);
+      dayStart.setHours(0, 0, 0, 0);
+      const dayEnd = new Date(day);
+      dayEnd.setHours(23, 59, 59, 999);
+
+      const ticketEventsForDay = events
+        .filter((event) => event.ticket_id === ticketId)
+        .filter((event) => {
+          const start = new Date(event.start_date);
+          const end = new Date(event.end_date);
+          return start <= dayEnd && end >= dayStart;
+        })
+        .sort((a, b) => new Date(a.start_date).getTime() - new Date(b.start_date).getTime());
+
+      if (ticketEventsForDay.length === 0) return null;
+
+      const first = ticketEventsForDay[0];
+      const start = new Date(first.start_date);
+      const end = new Date(first.end_date);
+
+      const formatTime = (d: Date) =>
+        d.toLocaleTimeString("en-US", {
+          hour: "numeric",
+          minute: "2-digit",
+        });
+
+      return `${formatTime(start)} - ${formatTime(end)}`;
+    },
+    [events, selectedDay],
+  );
+
   return (
-    <div className="flex h-full flex-col bg-white">
+    <div className="flex h-full flex-col">
       {/* Header */}
       <div className="flex-shrink-0 space-y-3 px-4 pb-4 sm:pt-4">
         <div className="flex items-center gap-2">
-          <Feather className="h-5 w-5 text-violet-800" />
-          <h3 className="text-lg font-semibold text-violet-950">Project Tickets</h3>
+          <div className="flex h-8 w-8 items-center justify-center rounded-xl bg-[var(--planner-sidebar-icon-bg)] text-[var(--accent)] shadow-[var(--planner-sidebar-icon-shadow)]">
+            <Feather className="h-4 w-4" />
+          </div>
+          <h3 className="text-lg font-semibold text-[var(--text)]">Project Tickets</h3>
         </div>
         {selectedDay && (
-          <div className="text-sm text-gray-600">
+          <div className="text-sm text-[var(--text-muted)]">
             {selectedDay.toLocaleDateString("en-US", {
               weekday: "long",
               year: "numeric",
@@ -311,7 +244,7 @@ export function TicketsSidebar({
           <select
             value={selectedProjectKey}
             onChange={(e) => onProjectChange(e.target.value)}
-            className="w-full appearance-none truncate rounded-lg border border-gray-300 bg-white py-2 pl-3 pr-9 text-sm font-medium text-gray-900 shadow-sm focus:outline-none focus:ring-2 focus:ring-gray-300"
+            className="w-full appearance-none truncate rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)] py-2 pl-3 pr-9 text-sm font-medium text-[var(--text)] shadow-sm focus:outline-none focus:ring-2 focus:ring-[var(--accent-soft)]"
           >
             {projects
               .filter((p) => p.project_status?.toLowerCase() === "in progress")
@@ -323,7 +256,7 @@ export function TicketsSidebar({
               ))}
             {projects.length === 0 && <option value="">No projects</option>}
           </select>
-          <ChevronDown className="pointer-events-none absolute right-2 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-500" />
+          <ChevronDown className="pointer-events-none absolute right-2 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text-muted)]" />
         </div>
 
         {/* Tab Navigation */}
@@ -331,7 +264,7 @@ export function TicketsSidebar({
           {/* Create ticket button */}
           <button
             onClick={handleOpenCreateModal}
-            className="flex h-8 w-8 items-center justify-center rounded-md bg-green-50 text-green-600 transition-colors hover:bg-green-100"
+            className="flex h-8 w-8 items-center justify-center rounded-md bg-[var(--accent-soft)] text-[var(--accent)] transition-colors hover:bg-[var(--accent-subtle)]"
           >
             <Plus className="h-4 w-4" />
           </button>
@@ -342,7 +275,9 @@ export function TicketsSidebar({
               onClick={() => setActiveTab("today")}
               className={cn(
                 "flex h-8 w-8 items-center justify-center rounded-md transition-colors",
-                activeTab === "today" ? "bg-violet-100 text-violet-700" : "text-gray-500 hover:bg-gray-100 hover:text-gray-700",
+                activeTab === "today"
+                  ? "bg-[var(--accent-soft)] text-[var(--accent)]"
+                  : "text-[var(--text-muted)] hover:bg-[var(--accent-subtle)] hover:text-[var(--accent)]",
               )}
             >
               <CalendarDays className="h-4 w-4" />
@@ -351,7 +286,9 @@ export function TicketsSidebar({
               onClick={() => setActiveTab("unscheduled")}
               className={cn(
                 "flex h-8 w-8 items-center justify-center rounded-md transition-colors",
-                activeTab === "unscheduled" ? "bg-violet-100 text-violet-700" : "text-gray-500 hover:bg-gray-100 hover:text-gray-700",
+                activeTab === "unscheduled"
+                  ? "bg-[var(--accent-soft)] text-[var(--accent)]"
+                  : "text-[var(--text-muted)] hover:bg-[var(--accent-subtle)] hover:text-[var(--accent)]",
               )}
             >
               <Clock className="h-4 w-4" />
@@ -360,7 +297,9 @@ export function TicketsSidebar({
               onClick={() => setActiveTab("backlog")}
               className={cn(
                 "flex h-8 w-8 items-center justify-center rounded-md transition-colors",
-                activeTab === "backlog" ? "bg-violet-100 text-violet-700" : "text-gray-500 hover:bg-gray-100 hover:text-gray-700",
+                activeTab === "backlog"
+                  ? "bg-[var(--accent-soft)] text-[var(--accent)]"
+                  : "text-[var(--text-muted)] hover:bg-[var(--accent-subtle)] hover:text-[var(--accent)]",
               )}
             >
               <Archive className="h-4 w-4" />
@@ -373,308 +312,48 @@ export function TicketsSidebar({
       <ScrollArea className="flex-1">
         <div ref={ticketsListRef} className="space-y-2 p-2">
           {filteredTickets.length === 0 ? (
-            <div className="p-4 text-center text-sm text-gray-500">{!selectedProjectKey ? "Select a project" : "No tickets available"}</div>
+            <div className="p-4 text-center text-sm text-[var(--text-muted)]">{!selectedProjectKey ? "Select a project" : "No tickets available"}</div>
           ) : (
             filteredTickets.map((ticket) => {
               const isDone = ticket.ticket_status?.toLowerCase() === "done";
               const isEventToday = activeTab === "today" && ticket.ticket_type?.toLowerCase() === "event";
+              const eventTimeRange = isEventToday && ticket.ticket_type?.toLowerCase() === "event" ? getEventTimeRangeForTicket(ticket.ticket_id) : null;
               return (
-                <Card
+                <TicketCard
                   key={ticket.ticket_id}
-                  className={cn(
-                    "rounded-lg border p-3",
-                    !isEventToday && "draggable-ticket cursor-grab active:cursor-grabbing",
-                    "touch-manipulation",
-                    isEventToday
-                      ? "border-gray-200 bg-gray-50 shadow-none" // Flat, non-draggable look for event tickets
-                      : isDone
-                        ? "border-gray-100 bg-gray-50 opacity-75 shadow-sm"
-                        : "border-gray-200 bg-white shadow-sm hover:border-gray-300 hover:shadow-md",
-                  )}
-                  data-ticket-id={isEventToday ? undefined : ticket.ticket_id}
-                  data-title={isEventToday ? undefined : ticket.title}
-                  data-project-id={isEventToday ? undefined : ticket.project_id}
-                  onClick={() => onTicketClick(ticket)}
-                  style={{
-                    willChange: "transform",
-                    backfaceVisibility: "hidden",
-                    transform: "translateZ(0)",
-                  }}
-                >
-                  {/* Ticket header: type icon + key + status pill */}
-                  <div className="mb-2 flex items-center justify-between">
-                    <div className="flex items-center gap-2">
-                      <span className="flex h-4 w-4 flex-shrink-0 items-center justify-center">{ticketTypeIcon(ticket.ticket_type, isDone)}</span>
-                      <span className={cn("text-xs font-medium", isDone ? "text-gray-500" : "text-gray-600")}>{ticket.ticket_key}</span>
-                    </div>
-                    {!isEventToday && (
-                      <Badge className={cn("rounded-full px-2 py-0.5 text-xs font-semibold", statusPillClasses(ticket.ticket_status))}>
-                        {ticket.ticket_status}
-                      </Badge>
-                    )}
-                  </div>
-
-                  {/* Ticket title */}
-                  <p className={cn("mb-2 line-clamp-2 text-sm font-medium leading-tight", isDone ? "text-gray-500 line-through" : "text-gray-900")}>
-                    {ticket.title}
-                  </p>
-
-                  {/* Epic + scheduled date and schedule controls row (matches legacy layout) */}
-                  <div className="flex items-center justify-between">
-                    {/* Epic on the left */}
-                    <div className="flex min-w-0 flex-shrink items-center gap-2">
-                      {ticket.epic && (
-                        <>
-                          <span className="flex h-4 w-4 flex-shrink-0 items-center justify-center">
-                            <Diamond className={cn("h-3 w-3", isDone ? "text-gray-400" : "text-purple-600")} />
-                          </span>
-                          <span className={cn("truncate text-xs", isDone ? "text-gray-400" : "text-gray-600")}>{ticket.epic}</span>
-                        </>
-                      )}
-                    </div>
-
-                    {/* Scheduled date + schedule/unschedule on the right */}
-                    <div className="flex items-center gap-2">
-                      {!isEventToday && (
-                        <>
-                          {ticket.scheduled_date && !isDone && (
-                            <span className="flex-shrink-0 text-xs text-violet-600">
-                              {new Date(ticket.scheduled_date).toLocaleDateString("en-US", {
-                                month: "short",
-                                day: "numeric",
-                              })}
-                            </span>
-                          )}
-
-                          {!isDone && ticket.scheduled_date && onUnscheduleTicket && (
-                            <button
-                              type="button"
-                              onClick={(e) => {
-                                e.preventDefault();
-                                e.stopPropagation();
-                                onUnscheduleTicket(ticket.ticket_id);
-                              }}
-                              className="flex h-6 w-6 cursor-pointer items-center justify-center rounded-md bg-orange-50 text-orange-600 transition-colors hover:bg-orange-100"
-                            >
-                              <CalendarMinus className="h-3 w-3" />
-                            </button>
-                          )}
-
-                          {!isDone && onScheduleTicket && (
-                            <button
-                              type="button"
-                              onClick={(e) => {
-                                e.preventDefault();
-                                e.stopPropagation();
-
-                                const rect = (e.currentTarget as HTMLButtonElement).getBoundingClientRect();
-                                const calendarWidth = 288;
-                                const calendarHeight = 320;
-
-                                let x = rect.right - calendarWidth;
-                                let y = rect.bottom + 4;
-
-                                if (x < 8) x = 8;
-                                if (x + calendarWidth > window.innerWidth - 8) {
-                                  x = window.innerWidth - calendarWidth - 8;
-                                }
-                                if (y + calendarHeight > window.innerHeight - 8) {
-                                  y = rect.top - calendarHeight - 4;
-                                }
-
-                                setTicketSchedulePicker({ ticketId: ticket.ticket_id, x, y });
-                              }}
-                              className="flex h-6 w-6 cursor-pointer items-center justify-center rounded-md bg-violet-50 text-violet-600 transition-colors hover:bg-violet-100"
-                            >
-                              <CalendarPlus className="h-3 w-3" />
-                            </button>
-                          )}
-                        </>
-                      )}
-                    </div>
-                  </div>
-                </Card>
+                  ticket={ticket}
+                  isDone={isDone}
+                  isEventToday={isEventToday}
+                  eventTimeRange={eventTimeRange}
+                  onTicketClick={onTicketClick}
+                  onUnscheduleTicket={onUnscheduleTicket}
+                  onOpenSchedulePicker={
+                    onScheduleTicket
+                      ? (ticketId, position) => {
+                          setTicketSchedulePicker((prev) => {
+                            // Toggle: close if already open for this ticket
+                            if (prev?.ticketId === ticketId) {
+                              return null;
+                            }
+                            return { ticketId, ...position };
+                          });
+                        }
+                      : undefined
+                  }
+                />
               );
             })
           )}
         </div>
       </ScrollArea>
 
-      <Dialog open={isCreateModalOpen} onOpenChange={(open) => (open ? setIsCreateModalOpen(true) : handleCloseCreateModal())}>
-        <DialogContent
-          className="max-w-md rounded-2xl border border-gray-200 bg-white p-6 shadow-xl sm:max-w-lg sm:p-8"
-          onInteractOutside={(event) => {
-            event.preventDefault();
-          }}
-        >
-          <DialogHeader className="mb-4">
-            <DialogTitle className="text-lg font-semibold text-gray-900">Ticket Title</DialogTitle>
-          </DialogHeader>
-
-          <div className="space-y-5">
-            <div>
-              <input
-                type="text"
-                value={newTicketTitle}
-                onChange={(e) => setNewTicketTitle(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    e.preventDefault();
-                    void handleCreateTicketClick();
-                  }
-                }}
-                placeholder="Enter ticket title..."
-                autoFocus
-                className="w-full rounded-xl border border-violet-400 px-3 py-2 text-sm shadow-[0_0_0_1px_rgba(129,140,248,0.4)] focus:border-violet-500 focus:outline-none focus:ring-2 focus:ring-violet-300"
-              />
-            </div>
-
-            <div className="flex items-center justify-between gap-3 text-xs text-gray-700">
-              {/* Project dropdown */}
-              <div className="flex items-center gap-1.5">
-                <Feather className="h-3.5 w-3.5 text-gray-500" />
-                <div className="relative">
-                  <select
-                    value={newTicketProjectKey}
-                    onChange={(e) => setNewTicketProjectKey(e.target.value)}
-                    className="w-[160px] cursor-pointer appearance-none rounded-full border border-gray-300 bg-white px-3 py-1 pr-7 text-[11px] font-medium text-gray-800 shadow-sm outline-none hover:border-gray-400 hover:bg-gray-50 sm:w-[220px]"
-                  >
-                    {projects.map((project) => (
-                      <option key={project.project_key} value={project.project_key}>
-                        {project.title}
-                      </option>
-                    ))}
-                  </select>
-                  <ChevronDown className="pointer-events-none absolute right-2 top-1/2 h-3 w-3 -translate-y-1/2 text-gray-500" />
-                </div>
-              </div>
-
-              {/* Type + calendar controls */}
-              <div className="flex items-center gap-3">
-                <div className="flex items-center gap-1.5">
-                  <div className="relative">
-                    <select
-                      value={newTicketType}
-                      onChange={(e) => setNewTicketType(e.target.value as TicketType)}
-                      className="w-[90px] cursor-pointer appearance-none rounded-full border border-violet-200 bg-violet-50 px-2 py-0.5 pr-6 text-center text-[11px] font-medium text-violet-700 outline-none hover:bg-violet-100"
-                    >
-                      <option value="task">Task</option>
-                      <option value="story">Story</option>
-                      <option value="bug">Bug</option>
-                      <option value="event">Event</option>
-                    </select>
-                    <ChevronDown className="pointer-events-none absolute right-1.5 top-1/2 h-3 w-3 -translate-y-1/2 text-violet-500" />
-                  </div>
-                </div>
-
-                <div className="flex items-center gap-2">
-                  {newTicketScheduledDate && newTicketType !== "event" && (
-                    <button
-                      type="button"
-                      onClick={() => setNewTicketScheduledDate(null)}
-                      className="flex cursor-pointer items-center gap-1 text-[11px] font-medium text-violet-700 hover:text-violet-900"
-                    >
-                      <span>
-                        {new Date(newTicketScheduledDate).toLocaleDateString("en-US", {
-                          month: "short",
-                          day: "numeric",
-                        })}
-                      </span>
-                      <span className="text-[10px] text-gray-400">×</span>
-                    </button>
-                  )}
-
-                  {newTicketType !== "event" && (
-                    <button
-                      type="button"
-                      onClick={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-
-                        if (showCalendarPicker) {
-                          setShowCalendarPicker(false);
-                        } else {
-                          const rect = e.currentTarget.getBoundingClientRect();
-                          const calendarWidth = 288;
-                          const calendarHeight = 320;
-
-                          let x = rect.right - calendarWidth;
-                          let y = rect.bottom + 4;
-
-                          if (x < 8) x = 8;
-                          if (x + calendarWidth > window.innerWidth - 8) {
-                            x = window.innerWidth - calendarWidth - 8;
-                          }
-                          if (y + calendarHeight > window.innerHeight - 8) {
-                            y = rect.top - calendarHeight - 4;
-                          }
-
-                          setCalendarPickerPosition({ x, y });
-                          setShowCalendarPicker(true);
-                        }
-                      }}
-                      className={cn(
-                        "flex h-8 w-8 cursor-pointer items-center justify-center rounded-lg border border-violet-100 text-violet-600 shadow-sm",
-                        showCalendarPicker || newTicketScheduledDate ? "bg-violet-50" : "bg-white hover:bg-violet-50",
-                      )}
-                    >
-                      <CalendarDays className="h-4 w-4" />
-                    </button>
-                  )}
-                </div>
-              </div>
-            </div>
-
-            <div className="pt-1">
-              <Button
-                className="mb-4 h-11 w-full cursor-pointer justify-center rounded-xl bg-gray-200 text-sm font-semibold text-gray-500 hover:bg-gray-200"
-                disabled={isCreatingTicket || !newTicketTitle.trim()}
-                onClick={handleCreateTicketClick}
-              >
-                {isCreatingTicket ? "Creating..." : "Create Ticket"}
-              </Button>
-
-              <div className="flex items-center justify-center gap-3 pb-3 text-[11px] font-medium uppercase tracking-wide text-gray-400">
-                <span className="h-px w-10 bg-gray-200 sm:w-16" />
-                <span>or</span>
-                <span className="h-px w-10 bg-gray-200 sm:w-16" />
-              </div>
-
-              <Button
-                type="button"
-                variant="outline"
-                className="h-11 w-full justify-center rounded-xl border-gray-300 text-sm font-medium text-gray-700 hover:bg-gray-50"
-                // TODO: Implement create-from-image flow
-                disabled
-              >
-                Create from Image
-              </Button>
-            </div>
-          </div>
-        </DialogContent>
-        {showCalendarPicker && newTicketType !== "event" && (
-          <DialogPortal>
-            <div
-              className="fixed"
-              style={{ left: `${calendarPickerPosition.x}px`, top: `${calendarPickerPosition.y}px`, zIndex: 60, pointerEvents: "auto" }}
-              onClick={(e) => e.stopPropagation()}
-            >
-              <CalendarCard
-                initialDate={newTicketScheduledDate ? new Date(newTicketScheduledDate) : new Date()}
-                minDate={new Date()}
-                onSelect={(date: Date) => {
-                  const year = date.getFullYear();
-                  const month = String(date.getMonth() + 1).padStart(2, "0");
-                  const day = String(date.getDate()).padStart(2, "0");
-                  const selectedDate = `${year}-${month}-${day}`;
-                  setNewTicketScheduledDate(selectedDate);
-                  setShowCalendarPicker(false);
-                }}
-              />
-            </div>
-          </DialogPortal>
-        )}
-      </Dialog>
+      <TicketCreateModal
+        open={isCreateModalOpen}
+        projects={projects}
+        selectedProjectKey={selectedProjectKey}
+        onClose={() => setIsCreateModalOpen(false)}
+        onCreateTicket={onCreateTicket}
+      />
 
       {ticketSchedulePicker && (
         <div

--- a/src/hooks/useCalendarEvents.ts
+++ b/src/hooks/useCalendarEvents.ts
@@ -3,7 +3,7 @@ import { deleteEvent as apiDeleteEvent, updateEvent as apiUpdateEvent, fetchEven
 import { useWebSocketMessages } from "@/hooks/useWebSocketMessages";
 import type { CalendarEvent } from "@/types/calendar";
 import { getWeekCacheKey, getWeekStart } from "@/utils/calendar-utils";
-import { isAbortError } from "../utils/error-utils";
+import { isAbortError } from "@/utils/error-utils";
 
 /**
  * Hook for managing calendar events with caching, debouncing, and WebSocket updates

--- a/src/hooks/usePlannerTheme.ts
+++ b/src/hooks/usePlannerTheme.ts
@@ -1,0 +1,93 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * usePlannerTheme
+ *
+ * CC-48: Soft Light/Dark Theming for Planner
+ *
+ * This hook manages the current theme for the planner experience. It is
+ * intentionally scoped to the planner for now but can be generalised
+ * later if a global theming system is introduced.
+ */
+
+export type PlannerThemeName = "soft-light" | "soft-dark";
+
+export interface UsePlannerThemeResult {
+  /** The currently selected planner theme. */
+  theme: PlannerThemeName;
+  /**
+   * Convenience class name to apply to the planner layout root.
+   *
+   * Example usage:
+   *   const { containerClass } = usePlannerTheme();
+   *   return <div className={cn(containerClass, "h-full")}>
+   *     ...
+   *   </div>
+   */
+  containerClass: string;
+  /** Setter for switching between themes. */
+  setTheme: (theme: PlannerThemeName) => void;
+}
+
+const STORAGE_KEY = "plannerTheme";
+
+function getInitialTheme(): PlannerThemeName {
+  if (typeof window === "undefined") {
+    return "soft-light";
+  }
+
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  if (stored === "soft-light" || stored === "soft-dark") {
+    return stored;
+  }
+
+  if (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) {
+    return "soft-dark";
+  }
+
+  return "soft-light";
+}
+
+export function usePlannerTheme(): UsePlannerThemeResult {
+  // IMPORTANT: Always start from a stable default so the first
+  // server render matches the first client render. We then
+  // hydrate to the real theme preference in an effect.
+  const [theme, setTheme] = useState<PlannerThemeName>("soft-light");
+
+  // On mount, determine the actual preferred theme using
+  // browser APIs (localStorage / matchMedia) and update.
+  useEffect(() => {
+    const initial = getInitialTheme();
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setTheme(initial);
+  }, []);
+
+  // Persist theme to localStorage whenever it changes in the browser.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(STORAGE_KEY, theme);
+  }, [theme]);
+
+  // Also apply the theme class to document.body so elements created
+  // outside the planner layout tree (e.g. drag mirrors) still receive
+  // the same CSS custom properties and visual styling.
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+
+    const body = document.body;
+    const nextClass = theme === "soft-light" ? "theme-soft-light" : "theme-soft-dark";
+
+    body.classList.remove("theme-soft-light", "theme-soft-dark");
+    body.classList.add(nextClass);
+
+    return () => {
+      body.classList.remove("theme-soft-light", "theme-soft-dark");
+    };
+  }, [theme]);
+
+  const containerClass = theme === "soft-light" ? "theme-soft-light" : "theme-soft-dark";
+
+  return { theme, setTheme, containerClass };
+}

--- a/src/hooks/useTickets.ts
+++ b/src/hooks/useTickets.ts
@@ -3,7 +3,7 @@ import { fetchTickets } from "@/api/tickets";
 import { useWebSocketMessages } from "@/hooks/useWebSocketMessages";
 import type { Project } from "@/types/project";
 import type { Ticket } from "@/types/ticket";
-import { isAbortError } from "../utils/error-utils";
+import { isAbortError } from "@/utils/error-utils";
 
 /**
  * Hook for managing project tickets with caching

--- a/src/styles/calendar.css
+++ b/src/styles/calendar.css
@@ -1,10 +1,29 @@
-:root {
+/*
+ * FullCalendar theming
+ *
+ * We scope light/dark styling via the planner theme classes so
+ * the calendar inherits the same tokens as the rest of the UI.
+ */
+
+/* Light (default) */
+:root,
+.theme-soft-light {
   /* Make the grid white & lines subtle */
   --fc-border-color: #e5e7eb; /* gray-200 */
   --fc-page-bg-color: #ffffff;
   --fc-neutral-bg-color: #ffffff; /* remove yellow wash */
   --fc-today-bg-color: transparent;
   --fc-now-indicator-color: #ef4444;
+}
+
+/* Dark theme overrides */
+.theme-soft-dark {
+  /* Slightly lifted near-black background that still shows grid */
+  --fc-border-color: rgba(148, 163, 184, 0.35); /* slate-400-ish */
+  --fc-page-bg-color: transparent; /* let planner surface show through */
+  --fc-neutral-bg-color: transparent;
+  --fc-today-bg-color: rgba(37, 99, 235, 0.09); /* subtle blue wash */
+  --fc-now-indicator-color: #f97316; /* warm orange now-line */
 }
 .fc {
   font-family:
@@ -28,6 +47,11 @@
 .fc .fc-timegrid-slot-label-cushion {
   color: #6b7280; /* gray-500 */
 }
+/* Style the all-day row label (now a sun icon) */
+.fc .fc-timegrid-axis.fc-timegrid-axis-all-day .fc-timegrid-axis-cushion {
+  font-size: 0.8rem;
+  color: var(--accent, #2563eb);
+}
 /* Slot height for air */
 .fc .fc-timegrid-slot {
   height: 3.25rem;
@@ -48,24 +72,45 @@
 .fc {
   touch-action: manipulation;
 }
+.fc .fc-timegrid-col.fc-timegrid-col-all-day .fc-timegrid-col-frame {
+  /* Make all-day row very compact so only header content fits */
+  min-height: 2.25rem;
+  max-height: 2.5rem;
+  overflow: hidden;
+}
+.fc .fc-scrollgrid {
+  /* Round only the top corners of the main calendar grid/table */
+  border-radius: 16px 16px 0 0;
+  overflow: hidden;
+  /* Distinct background for the grid area to create depth
+     (lighter than the surrounding card in dark mode, slightly darker
+     than the card in light mode). */
+  background: radial-gradient(circle at top left, rgba(37, 99, 235, 0.06), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(37, 99, 235, 0.04), transparent 65%), var(--planner-grid-bg, #f3f4f6);
+}
+.fc .fc-view-harness {
+  /* Add horizontal breathing room so the main grid lines up visually
+     with the outer header controls (date pill and Today arrows). */
+  margin-inline: 1rem; /* 16px, roughly matching header padding */
+}
 .fc .fc-timegrid-body,
 .fc .fc-timegrid-slots {
   touch-action: pan-y pinch-zoom;
 }
 
-/* Selected day column highlighting - subtle styling */
+/* Selected day column highlighting - subtle styling (blue accent) */
 .fc .fc-day-selected {
-  background-color: rgba(124, 58, 237, 0.03) !important; /* Very subtle violet background */
+  background-color: var(--accent-subtle, rgba(37, 99, 235, 0.05)) !important; /* Very subtle blue background */
 }
 
 /* Selected day header styling - minimal emphasis */
 .fc .fc-col-header-cell.fc-day-selected {
-  background-color: rgba(124, 58, 237, 0.05) !important; /* Subtle header background */
+  background-color: var(--accent-soft, rgba(37, 99, 235, 0.12)) !important; /* Subtle header background */
   font-weight: 500; /* Slightly bolder but not too obvious */
-  color: #6b46c1; /* Slightly muted violet */
+  color: var(--accent, #2563eb); /* Accent blue */
 }
 
 /* Ensure selected styling applies to entire column - very subtle */
 .fc .fc-timegrid-col.fc-day-selected {
-  background-color: rgba(124, 58, 237, 0.02) !important; /* Barely visible tint */
+  background-color: rgba(37, 99, 235, 0.02) !important; /* Barely visible tint */
 }

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -1,0 +1,209 @@
+/*
+ * Global application theming for Command Centre
+ *
+ * This file defines soft, inviting light and dark theme palettes using
+ * CSS custom properties (design tokens). These tokens SHOULD be reused
+ * across new pages and components, not just the planner, unless a token
+ * is explicitly marked as planner-specific.
+ *
+ * Usage guidelines:
+ * - Scope themes using one of the theme classes (e.g. on a layout root):
+ *   - .theme-soft-light
+ *   - .theme-soft-dark
+ * - Within React components, prefer Tailwind utilities that reference
+ *   these variables, e.g.:
+ *   - bg-[var(--surface)]
+ *   - text-[var(--text-muted)]
+ *   - border-[var(--border-subtle)]
+ * - When a feature area needs custom tuning, derive area-specific tokens
+ *   from the global ones (e.g. --planner-surface: var(--surface)).
+ */
+
+/* :root reserved for future global, non-theme-specific tokens if needed. */
+
+/*
+ * Soft Light Theme
+ * - Warm, low-contrast backgrounds
+ * - Soft coral accent for primary actions
+ * - Muted greens and purples for positive/secondary accents
+ */
+
+.theme-soft-light {
+  /* Base colours */
+  background-color: var(--app-bg);
+  color: var(--text);
+
+  /* Global structure tokens */
+  /* Soft, neutral gray background with white surfaces */
+  --app-bg: #f1f3f4;
+  --surface: #ffffff;
+  --surface-muted: #e5e7eb;
+  --surface-elevated: #ffffff;
+
+  /* Borders & outlines */
+  --border-subtle: #e4e4e7;
+  --border-strong: #d4d4d8;
+
+  /* Event/completion accents */
+  /* Slightly darker grey for completed event overlays to remain visible over event backgrounds */
+  --event-completed-stripe: #9ca3af;
+
+  /* Text */
+  --text: #1f2933;
+  --text-muted: #6b7280;
+  --text-on-accent: #ffffff;
+
+  /* Accents - professional, friendly blue */
+  --accent: #2563eb; /* blue-600 */
+  --accent-soft: rgba(37, 99, 235, 0.12);
+  --accent-subtle: rgba(37, 99, 235, 0.06);
+
+  /* Secondary accent - meeting purple */
+  --accent-meeting: #7c3aed; /* violet-600 */
+  --accent-meeting-soft: rgba(124, 58, 237, 0.16);
+
+  /* Status colours */
+  --success: #34d399; /* emerald */
+  --warning: #fbbf24; /* amber */
+  --danger: #fb7185; /* rose */
+
+  /* Application-specific derived tokens */
+  /*
+   * Planner derived tokens
+   * - These are intentionally scoped as planner-* but are defined here so
+   *   they can be themed consistently with the rest of the app.
+   */
+  --planner-bg: var(--app-bg);
+  --planner-surface: var(--surface);
+  --planner-sidebar-bg: #f7f7f8; /* slightly lighter than surface-muted */
+  --planner-time-column-bg: #f5f5f7;
+  --planner-time-indicator: var(--accent);
+  --planner-event-bg: #f5f5ff;
+  --planner-event-border: #e4e4f7;
+  --planner-event-selected-border: var(--accent);
+
+  --planner-label-pill-bg: var(--accent-soft);
+  --planner-label-pill-text: var(--accent);
+
+  --planner-card-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  --planner-surface-radius: 24px;
+
+  /* Calendar grid background (slightly darker than main card) */
+  --planner-grid-bg: #f3f4f6;
+
+  /* Sidebar icon tile (Project Tickets) */
+  --planner-sidebar-icon-bg: #ffffff;
+  --planner-sidebar-icon-shadow: 0 6px 18px rgba(15, 23, 42, 0.08);
+}
+
+/*
+ * Soft Dark Theme
+ * - Deep navy/charcoal background
+ * - Pastel pink/purple accents
+ * - Maintain good contrast for text and timeline labels
+ */
+
+.theme-soft-dark {
+  /* Base colours */
+  background-color: var(--app-bg);
+  color: var(--text);
+
+  /* Global structure tokens */
+  /*
+   * Jet-black professional neutrals
+   * - app-bg: lighter outer background
+   * - surface: main panels / cards (darker)
+   * - elevated: lighter inner cards / chips / grid
+   * Keep these greyscale so the blue accent stands out.
+   */
+  --app-bg: #141414; /* outer page background (clean neutral grey) */
+  --surface: #050505; /* main panels/cards - deep near-black */
+  --surface-muted: #0a0a0a; /* muted chips, subtle controls */
+  --surface-elevated: #1f1f23; /* elevated cards, headers, grid */
+
+  /* Borders & outlines */
+  --border-subtle: #2b2b32; /* soft outline between surfaces */
+  --border-strong: #3a3a45; /* stronger separators */
+
+  /* Event/completion accents */
+  /* Darker mid-grey for completed event overlays in dark mode */
+  --event-completed-stripe: #6b7280;
+
+  /* Text */
+  --text: #e5e7eb;
+  --text-muted: #9ca3af;
+  --text-on-accent: #ffffff;
+
+  /* Accents - brighter blue for dark theme */
+  --accent: #60a5fa; /* blue-400 */
+  --accent-soft: rgba(96, 165, 250, 0.22);
+  --accent-subtle: rgba(96, 165, 250, 0.12);
+
+  /* Secondary accent - meeting purple (lighter in dark mode) */
+  --accent-meeting: #c990ff;
+  --accent-meeting-soft: rgba(168, 85, 247, 0.28);
+
+  /* Status colours */
+  --success: #4ade80; /* brighter green */
+  --warning: #facc15;
+  --danger: #fb7185;
+
+  /* Planner derived tokens */
+  /*
+   * Dark mode depth (jet black):
+   * - Background: lighter deep neutral
+   * - Main calendar surface: darker panel
+   * - Sidebar/nav: darkest rail
+   * - Grid/elevated content: slightly lighter inner panel
+   */
+  --planner-bg: radial-gradient(circle at top left, #141414, #141414);
+  --planner-surface: #050505; /* main calendar card - darker than app bg */
+  --planner-sidebar-bg: #000000; /* nav rail / outer sidebar - darkest */
+  --planner-sidebar-surface: #050505; /* ticket list surface matches card */
+  --planner-time-column-bg: #050505; /* left time column matches card */
+  --planner-time-indicator: var(--accent);
+  --planner-event-bg: rgba(148, 163, 184, 0.14);
+  --planner-event-border: rgba(148, 163, 184, 0.5);
+  --planner-event-selected-border: var(--accent);
+
+  --planner-label-pill-bg: var(--accent-soft);
+  --planner-label-pill-text: #f9fafb;
+
+  --planner-card-shadow: 0 18px 40px rgba(15, 23, 42, 0.75);
+  --planner-surface-radius: 24px;
+
+  /* Calendar grid background (noticeably lighter than card for depth) */
+  --planner-grid-bg: #232329;
+
+  /* Sidebar icon tile (Project Tickets) */
+  --planner-sidebar-icon-bg: var(--accent-subtle);
+  --planner-sidebar-icon-shadow: 0 10px 25px rgba(0, 0, 0, 0.6);
+}
+
+/* Shared interaction affordance: anything clickable should use pointer cursor */
+.theme-soft-light button,
+.theme-soft-dark button,
+.theme-soft-light [role="button"],
+.theme-soft-dark [role="button"],
+.theme-soft-light a[href],
+.theme-soft-dark a[href],
+.theme-soft-light summary,
+.theme-soft-dark summary,
+.theme-soft-light select,
+.theme-soft-dark select,
+.theme-soft-light input[type="button"],
+.theme-soft-dark input[type="button"],
+.theme-soft-light input[type="submit"],
+.theme-soft-dark input[type="submit"],
+.theme-soft-light input[type="reset"],
+.theme-soft-dark input[type="reset"],
+.theme-soft-light input[type="checkbox"],
+.theme-soft-dark input[type="checkbox"],
+.theme-soft-light input[type="radio"],
+.theme-soft-dark input[type="radio"],
+.theme-soft-light input[type="file"],
+.theme-soft-dark input[type="file"],
+.theme-soft-light input[type="range"],
+.theme-soft-dark input[type="range"] {
+  cursor: pointer;
+}

--- a/src/utils/calendar-popover-position.ts
+++ b/src/utils/calendar-popover-position.ts
@@ -1,0 +1,25 @@
+export function getAnchoredPopoverPosition(
+  triggerRect: DOMRect,
+  popoverWidth: number,
+  popoverHeight: number,
+  viewportWidth?: number,
+  viewportHeight?: number,
+  margin = 8,
+): { x: number; y: number } {
+  const vw = viewportWidth ?? (typeof window !== "undefined" ? window.innerWidth : popoverWidth);
+  const vh = viewportHeight ?? (typeof window !== "undefined" ? window.innerHeight : popoverHeight);
+
+  let x = triggerRect.right - popoverWidth;
+  let y = triggerRect.bottom + 4;
+
+  if (x < margin) x = margin;
+  if (x + popoverWidth > vw - margin) {
+    x = vw - popoverWidth - margin;
+  }
+
+  if (y + popoverHeight > vh - margin) {
+    y = triggerRect.top - popoverHeight - 4;
+  }
+
+  return { x, y };
+}


### PR DESCRIPTION
- Add global theme tokens and planner-specific CSS variables in themes.css
- Create usePlannerTheme hook and PlannerNavBar component for theme toggle
- Update calendar components (header, view, events) to use theme tokens
- Refactor tickets sidebar with themed TicketCard and TicketCreateModal
- Implement ticket scheduling/unscheduling API and wire into planner page
- Add shared calendar popover positioning utility
- Consolidate error-utils imports to @/utils alias
- Add toggle behavior to CalendarCard popup in schedule button
- Remove scaffolding comments for production readiness