### PR TITLE
feat(calendar): implement time selection for event creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ This is a living document maintained to track feature additions, bug fixes, and 
 
 ## [Completed]
 
+### CC-55: Calendar Time Selection for Event Creation - 2026-01-07
+
+- Implement time selection context menu with "Create Event" and "Schedule Break" actions
+- Add `useCalendarSelection` hook for managing calendar time selection state
+- Create reusable `ContextMenuButton` component for context menu actions
+- Refactor `CalendarContextMenu` to support both event and selection menu types (union type)
+- Add optimistic UI updates for newly created calendar events
+- Integrate time selection into planner page with `TicketCreateModal` support
+- Add date-time utilities (`toTimezone`, `parseInTimezone`) for timezone handling
+- Support creating events directly from calendar time selection drag
+- Update API client to handle event creation with start/end dates
+- Display visual indicators for optimistic events (loading state overlay)
+
 ### CC-48: Soft Light/Dark Theming for Planner - 2026-01-02
 
 - Define soft light/dark global theme tokens and planner-specific CSS variables, and load them via the app root layout
@@ -27,12 +40,14 @@ This is a living document maintained to track feature additions, bug fixes, and 
 - Add toggle behavior to CalendarCard popup in TicketCard schedule button
 
 ### Project Setup & Configuration - 2025-12-31
+
 - Added CHANGELOG.md for tracking project changes
 - Created GitHub Copilot instructions document
 - Installed shadcn/ui dependencies (class-variance-authority, lucide-react)
 - Configured shadcn/ui with New York style and Tailwind CSS 4
 
 ### CC-45: Refactor Planner Page with New Component Library - 2026-01-01
+
 - [x] Migrate planner page from legacy components to shadcn/ui architecture
 - [x] Create reusable calendar component wrapper around FullCalendar
 - [x] Support multiple calendar views (week, day) with configurable options

--- a/src/api/tickets.ts
+++ b/src/api/tickets.ts
@@ -1,6 +1,8 @@
 import type { Ticket, TicketsResponse } from "@/types/ticket";
 import { apiClient } from "./client";
 
+export const DEFAULT_CALENDAR_ID = "ethanjohol@gmail.com";
+
 /**
  * API functions for tickets
  */
@@ -23,6 +25,8 @@ export async function createTicket(
     internalProjectId: string;
     type?: string;
     scheduledDate?: string;
+    startDate?: string;
+    endDate?: string;
   },
   signal?: AbortSignal,
 ): Promise<Ticket> {
@@ -33,6 +37,12 @@ export async function createTicket(
     // API expects capitalized type strings like "Task" / "Event"
     type: (data.type ?? "task").charAt(0).toUpperCase() + (data.type ?? "task").slice(1),
     ...(data.scheduledDate && { scheduled_date: data.scheduledDate }),
+    ...(data.startDate &&
+      data.endDate && {
+        start_date: data.startDate,
+        end_date: data.endDate,
+        google_calendar_id: DEFAULT_CALENDAR_ID,
+      }),
   };
 
   const response = await apiClient.post("/tickets", payload, { signal });

--- a/src/components/calendar/CalendarContextMenu.tsx
+++ b/src/components/calendar/CalendarContextMenu.tsx
@@ -1,23 +1,25 @@
 "use client";
 
-import { useEffect, useRef } from "react";
-import { Edit, ExternalLink, Trash2 } from "lucide-react";
-import type { ContextMenu } from "@/hooks/useCalendarInteractions";
+import { type ReactNode, useEffect, useRef } from "react";
 import { Card } from "@/ui/card";
 
+// Union type for different context menu types
+export type CalendarContextMenuState =
+  | { show: boolean; x: number; y: number; type: "event"; eventId?: string; googleCalendarId?: string }
+  | { show: boolean; x: number; y: number; type: "selection"; startDate?: Date; endDate?: Date };
+
 interface CalendarContextMenuProps {
-  contextMenu: ContextMenu;
-  onEdit?: (eventId: string) => void;
-  onDelete?: (eventId: string) => void;
-  onOpenInCalendar?: (googleCalendarId: string) => void;
+  contextMenu: CalendarContextMenuState;
   onClose: () => void;
+  children: ReactNode;
 }
 
 /**
- * Context menu for calendar events (right-click or long-press)
+ * Context menu for calendar interactions (right-click events or time selections)
  * Touch-optimized with larger tap targets
+ * Accepts menu items as children for maximum flexibility
  */
-export function CalendarContextMenu({ contextMenu, onEdit, onDelete, onOpenInCalendar, onClose }: CalendarContextMenuProps) {
+export function CalendarContextMenu({ contextMenu, onClose, children }: CalendarContextMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
 
   // Close on click outside
@@ -69,43 +71,7 @@ export function CalendarContextMenu({ contextMenu, onEdit, onDelete, onOpenInCal
 
   return (
     <Card ref={menuRef} className="fixed z-50 w-48 rounded border border-gray-200 bg-white p-1 shadow-lg" style={{ left: contextMenu.x, top: contextMenu.y }}>
-      {/* Open Ticket */}
-      <button
-        onClick={() => {
-          if (contextMenu.eventId && onEdit) onEdit(contextMenu.eventId);
-          onClose();
-        }}
-        className="flex w-full items-center gap-3 rounded px-3 py-2.5 text-sm font-medium text-gray-900 transition-colors hover:bg-gray-100"
-      >
-        <Edit className="h-4 w-4" />
-        Open Ticket
-      </button>
-
-      {/* Delete */}
-      <button
-        onClick={() => {
-          if (contextMenu.eventId && onDelete) onDelete(contextMenu.eventId);
-          onClose();
-        }}
-        className="flex w-full items-center gap-3 rounded px-3 py-2.5 text-sm font-medium text-red-600 transition-colors hover:bg-red-50"
-      >
-        <Trash2 className="h-4 w-4" />
-        Delete Event
-      </button>
-
-      {/* Open in Calendar */}
-      {contextMenu.googleCalendarId && onOpenInCalendar && (
-        <button
-          onClick={() => {
-            onOpenInCalendar(contextMenu.googleCalendarId!);
-            onClose();
-          }}
-          className="flex w-full items-center gap-3 rounded px-3 py-2.5 text-sm font-medium text-gray-900 transition-colors hover:bg-gray-100"
-        >
-          <ExternalLink className="h-4 w-4" />
-          Open in Google Calendar
-        </button>
-      )}
+      {children}
     </Card>
   );
 }

--- a/src/components/calendar/CalendarEvent.tsx
+++ b/src/components/calendar/CalendarEvent.tsx
@@ -21,11 +21,14 @@ export function CalendarEvent({ eventInfo }: CalendarEventProps) {
   const bandColor = extendedProps?.bandColor || "var(--accent)";
   const showBand = extendedProps?.showBand !== false;
   const isCompleted = extendedProps?.ticket_status === "Done" || extendedProps?.ticket_status === "Removed" || extendedProps?.completed === true;
+  const isOptimistic = extendedProps?.isOptimistic === true;
 
   // All-day events: render as a compact header-only chip
   if (event.allDay) {
     return (
       <div className="relative flex h-full items-center overflow-hidden px-1.5 py-0.5">
+        {/* Optimistic overlay */}
+        {isOptimistic && <div className="pointer-events-none absolute inset-0 cursor-wait bg-gray-400/30" />}
         <div className="truncate text-[11px] font-semibold leading-tight sm:text-xs">{event.title}</div>
       </div>
     );
@@ -39,6 +42,9 @@ export function CalendarEvent({ eventInfo }: CalendarEventProps) {
       <div className="relative flex h-full items-center justify-between gap-1 overflow-hidden px-1.5 py-0.5">
         {/* Color band */}
         {showBand && <div className="absolute left-0 top-0 h-full w-1 flex-shrink-0 rounded-l" style={{ backgroundColor: bandColor }} />}
+
+        {/* Optimistic overlay */}
+        {isOptimistic && <div className="pointer-events-none absolute inset-0 cursor-wait bg-gray-400/30" />}
 
         {/* Completed overlay */}
         {isCompleted && (
@@ -70,6 +76,9 @@ export function CalendarEvent({ eventInfo }: CalendarEventProps) {
     <div className="relative h-full overflow-hidden p-1.5">
       {/* Color band */}
       {showBand && <div className="absolute left-0 top-0 h-full w-1 flex-shrink-0 rounded-l" style={{ backgroundColor: bandColor }} />}
+
+      {/* Optimistic overlay */}
+      {isOptimistic && <div className="pointer-events-none absolute inset-0 cursor-wait bg-gray-400/30" />}
 
       {/* Completed overlay */}
       {isCompleted && (

--- a/src/components/ui/context-menu-button.tsx
+++ b/src/components/ui/context-menu-button.tsx
@@ -1,0 +1,24 @@
+import type { LucideIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface ContextMenuButtonProps {
+  icon: LucideIcon;
+  children: React.ReactNode;
+  onClick: () => void;
+  variant?: "default" | "destructive";
+}
+
+export function ContextMenuButton({ icon: Icon, children, onClick, variant = "default" }: ContextMenuButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        "flex w-full items-center gap-3 rounded px-3 py-2.5 text-sm font-medium transition-colors",
+        variant === "destructive" ? "text-red-600 hover:bg-red-50" : "text-gray-900 hover:bg-gray-100",
+      )}
+    >
+      <Icon className="h-4 w-4" />
+      {children}
+    </button>
+  );
+}

--- a/src/hooks/useCalendarInteractions.ts
+++ b/src/hooks/useCalendarInteractions.ts
@@ -3,6 +3,7 @@ import type { DateSelectArg, EventClickArg, EventDropArg } from "@fullcalendar/c
 import type { DropArg, EventReceiveArg } from "@fullcalendar/interaction";
 import moment from "moment-timezone";
 import type { CalendarResizeArg } from "@/types/calendar";
+import { toTimezone } from "@/utils/date-utils";
 
 /**
  * Calendar interaction hooks for drag/drop, context menu, and touch interactions
@@ -237,8 +238,8 @@ export function useCalendarInteractions({
       try {
         const eventId = info.event.id;
         // Format dates in Sydney timezone (matching old implementation)
-        const newStartDate = moment.tz(info.event.start?.toISOString().replace(/Z$/, ""), "Australia/Sydney").format();
-        const newEndDate = moment.tz(info.event.end?.toISOString().replace(/Z$/, ""), "Australia/Sydney").format();
+        const newStartDate = toTimezone(info.event.start?.toISOString().replace(/Z$/, "") ?? "");
+        const newEndDate = toTimezone(info.event.end?.toISOString().replace(/Z$/, "") ?? "");
 
         const updates = {
           start_date: newStartDate,
@@ -259,8 +260,8 @@ export function useCalendarInteractions({
       try {
         const eventId = info.event.id;
         // Format dates in Sydney timezone (matching old implementation)
-        const newStartDate = moment.tz(info.event.start?.toISOString().replace(/Z$/, ""), "Australia/Sydney").format();
-        const newEndDate = moment.tz(info.event.end?.toISOString().replace(/Z$/, ""), "Australia/Sydney").format();
+        const newStartDate = toTimezone(info.event.start?.toISOString().replace(/Z$/, "") ?? "");
+        const newEndDate = toTimezone(info.event.end?.toISOString().replace(/Z$/, "") ?? "");
 
         const updates = {
           start_date: newStartDate,
@@ -286,8 +287,8 @@ export function useCalendarInteractions({
       try {
         const eventId = info.event.id;
         // Format dates in Sydney timezone (matching old implementation)
-        const newStartDate = moment.tz(info.event.start?.toISOString().replace(/Z$/, ""), "Australia/Sydney").format();
-        const newEndDate = moment.tz(info.event.end?.toISOString().replace(/Z$/, ""), "Australia/Sydney").format();
+        const newStartDate = toTimezone(info.event.start?.toISOString().replace(/Z$/, "") ?? "");
+        const newEndDate = toTimezone(info.event.end?.toISOString().replace(/Z$/, "") ?? "");
 
         const updates = {
           start_date: newStartDate,

--- a/src/hooks/useCalendarSelection.ts
+++ b/src/hooks/useCalendarSelection.ts
@@ -1,0 +1,69 @@
+import { useCallback, useState } from "react";
+import type { DateSelectArg } from "@fullcalendar/core";
+import { parseInTimezone } from "@/utils/date-utils";
+
+/**
+ * Selection context menu state
+ */
+export interface SelectionContextMenu {
+  show: boolean;
+  x: number;
+  y: number;
+  type: "selection";
+  startDate?: Date;
+  endDate?: Date;
+}
+
+/**
+ * Hook for managing calendar time selection and selection context menu
+ */
+export function useCalendarSelection() {
+  const [selectionContextMenu, setSelectionContextMenu] = useState<SelectionContextMenu>({
+    show: false,
+    x: 0,
+    y: 0,
+    type: "selection",
+  });
+
+  const handleDateSelect = useCallback((selectInfo: DateSelectArg) => {
+    if (!selectInfo.start || !selectInfo.end) return;
+
+    // Get the center of the selected time range for menu positioning
+    const jsEvent = selectInfo.jsEvent as MouseEvent | TouchEvent;
+    let x: number, y: number;
+
+    if (jsEvent instanceof MouseEvent) {
+      x = jsEvent.clientX;
+      y = jsEvent.clientY;
+    } else if (jsEvent instanceof TouchEvent && jsEvent.touches.length > 0) {
+      x = jsEvent.touches[0].clientX;
+      y = jsEvent.touches[0].clientY;
+    } else {
+      // Fallback to center of viewport if event details unavailable
+      x = window.innerWidth / 2;
+      y = window.innerHeight / 2;
+    }
+
+    const startMoment = parseInTimezone(selectInfo.startStr);
+    const endMoment = parseInTimezone(selectInfo.endStr);
+
+    setSelectionContextMenu({
+      show: true,
+      x,
+      y,
+      type: "selection",
+      startDate: startMoment.toDate(),
+      endDate: endMoment.toDate(),
+    });
+  }, []);
+
+  const hideSelectionContextMenu = useCallback(() => {
+    setSelectionContextMenu({ show: false, x: 0, y: 0, type: "selection" });
+  }, []);
+
+  return {
+    selectionContextMenu,
+    handleDateSelect,
+    hideSelectionContextMenu,
+  };
+}

--- a/src/old/components/application/calendars/TicketsList.tsx
+++ b/src/old/components/application/calendars/TicketsList.tsx
@@ -585,16 +585,20 @@ export default function TicketsList({
           const ticketId = eventEl.dataset.ticketId;
           const ticket = sorted.find((t) => t.ticket_id === ticketId);
           if (ticket) {
+            const project = projects.find((p) => p.project_key === projectKey);
             return {
               id: ticket.ticket_id,
               title: ticket.title,
               duration: "00:30:00", // Default 30 minutes duration
               extendedProps: {
-                showBand: false,
+                showBand: ticket.epic !== null && ticket.epic !== "" && ticket.epic !== undefined,
+                bandColor: ticket.colour,
+                ticket_id: ticket.ticket_id,
                 ticket_key: ticket.ticket_key,
                 ticket_type: ticket.ticket_type,
                 ticket_status: ticket.ticket_status,
-                project: projects.find((p) => p.project_key === projectKey),
+                completed: false,
+                project: project,
               },
             };
           }

--- a/src/types/calendar.ts
+++ b/src/types/calendar.ts
@@ -11,6 +11,7 @@ export interface CalendarEvent extends Ticket {
   google_calendar_id: string;
   all_day?: boolean;
   completed?: boolean;
+  isOptimistic?: boolean;
 }
 
 export interface EventsResponse {

--- a/src/utils/calendar-transform.ts
+++ b/src/utils/calendar-transform.ts
@@ -15,6 +15,7 @@ export function transformEventsToCalendarFormat(events: CalendarEvent[], project
       start: moment(event.start_date).tz("Australia/Sydney").format(),
       end: moment(event.end_date).tz("Australia/Sydney").format(),
       allDay: event.all_day,
+      editable: !event.isOptimistic, // Disable editing for optimistic events
       extendedProps: {
         showBand: event.epic !== null && event.epic !== "" && event.epic !== undefined,
         bandColor: event.colour,
@@ -24,6 +25,7 @@ export function transformEventsToCalendarFormat(events: CalendarEvent[], project
         google_calendar_id: event.google_calendar_id,
         completed: event.completed || false,
         project: event.project || projects.find((p) => p.project_id === event.project_id),
+        isOptimistic: event.isOptimistic,
       },
     };
 

--- a/src/utils/date-utils.ts
+++ b/src/utils/date-utils.ts
@@ -1,0 +1,26 @@
+import moment from "moment-timezone";
+
+/**
+ * The default timezone used across the application
+ */
+export const DEFAULT_TIMEZONE = "Australia/Sydney";
+
+/**
+ * Converts a date to the application's default timezone and formats it
+ * @param date - The date to convert (Date object or string)
+ * @param timezone - The timezone to convert to (defaults to Australia/Sydney)
+ * @returns ISO 8601 formatted string in the specified timezone
+ */
+export function toTimezone(date: Date | string, timezone: string = DEFAULT_TIMEZONE): string {
+  return moment.tz(date, timezone).format();
+}
+
+/**
+ * Parses a date string in the application's default timezone
+ * @param dateString - The date string to parse
+ * @param timezone - The timezone to parse in (defaults to Australia/Sydney)
+ * @returns Moment object in the specified timezone
+ */
+export function parseInTimezone(dateString: string, timezone: string = DEFAULT_TIMEZONE): moment.Moment {
+  return moment.tz(dateString, timezone);
+}


### PR DESCRIPTION
- Add time selection context menu with Create Event and Schedule Break actions
- Implement useCalendarSelection hook for managing selection state
- Create reusable ContextMenuButton component for menu actions
- Refactor CalendarContextMenu to support event and selection menu types
- Add optimistic UI updates with visual indicators for new events
- Integrate time selection with TicketCreateModal for event creation
- Add date-time utilities (toTimezone, parseInTimezone) for timezone handling
- Support creating events directly from calendar time drag selection
- Update API client to handle event creation with start/end dates
- Disable editing for optimistic events until server confirms