### PR TITLE
feat(planner): add hotbar-style creation interface for tickets and fo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ This is a living document maintained to track feature additions, bug fixes, and 
 
 ## [Completed]
 
+### Feature: Hotbar Creation Interface - CC-66 - 2026-01-14
+
+- Redesign ticket/focus creation from modal to hotbar-style popup
+- Add toggle between "Ticket" and "Focus" creation modes
+- Implement horizontal scrollable expandable options with caret indicators
+- Position hotbar centered with no background blur or shading
+- Support default type detection ("Event" from calendar, "Task" from + button)
+- Add image icon button for future "create from image" flow
+- Maintain quick, temporary feel with click-outside-to-dismiss behavior
+
 ### Refactor: Consolidate Ticket Type Colors - 2026-01-12
 
 - Consolidate all ticket type color definitions into themes.css CSS variables

--- a/src/api/calendar.ts
+++ b/src/api/calendar.ts
@@ -1,4 +1,4 @@
-import type { EventsResponse } from "@/types/calendar";
+import type { CreateBreakResponse, EventsResponse } from "@/types/calendar";
 import { apiClient } from "./client";
 
 /**
@@ -72,12 +72,12 @@ export async function createBreak(
     calendar_id?: string;
   },
   signal?: AbortSignal,
-): Promise<{ event_id: string }> {
+): Promise<CreateBreakResponse> {
   const response = await apiClient.post("/events/breaks", breakData, { signal });
 
   if (response.status !== 200) {
     throw new Error(`Failed to create break: ${response.status}`);
   }
 
-  return response.data as { event_id: string };
+  return response.data as CreateBreakResponse;
 }

--- a/src/api/projects.ts
+++ b/src/api/projects.ts
@@ -15,6 +15,33 @@ export async function fetchProjects(signal?: AbortSignal): Promise<ProjectsRespo
   return response.data as ProjectsResponse;
 }
 
+export async function createProject(
+  data: {
+    title: string;
+    description?: string;
+    colour?: string;
+    projectStatus?: string;
+    projectKey?: string;
+  },
+  signal?: AbortSignal,
+): Promise<Project> {
+  const payload = {
+    title: data.title,
+    ...(data.description && { description: data.description }),
+    ...(data.colour && { colour: data.colour }),
+    ...(data.projectStatus && { project_status: data.projectStatus }),
+    ...(data.projectKey && { project_key: data.projectKey }),
+  };
+
+  const response = await apiClient.post("/projects", payload, { signal });
+
+  if (response.status !== 200) {
+    throw new Error(`Failed to create project: ${response.status}`);
+  }
+
+  return response.data as Project;
+}
+
 export async function updateProjectTitle(projectId: string, title: string, signal?: AbortSignal): Promise<Project> {
   const response = await apiClient.patch(
     `/projects/${projectId}`,
@@ -61,4 +88,47 @@ export async function updateProjectColor(projectId: string, color: string, signa
   }
 
   return response.data as Project;
+}
+
+export async function updateProjectDescription(projectId: string, description: string, signal?: AbortSignal): Promise<Project> {
+  const response = await apiClient.patch(
+    `/projects/${projectId}`,
+    {
+      description: description,
+    },
+    { signal },
+  );
+
+  if (response.status !== 200) {
+    throw new Error(`Failed to update project description: ${response.status}`);
+  }
+
+  return response.data as Project;
+}
+
+export async function updateProjectStatus(projectId: string, status: string, signal?: AbortSignal): Promise<Project> {
+  const response = await apiClient.patch(
+    `/projects/${projectId}`,
+    {
+      project_status: status,
+    },
+    { signal },
+  );
+
+  if (response.status !== 200) {
+    throw new Error(`Failed to update project status: ${response.status}`);
+  }
+
+  return response.data as Project;
+}
+
+export async function deleteProject(projectId: string, signal?: AbortSignal): Promise<void> {
+  const response = await apiClient.delete(`/projects/${projectId}`, {
+    data: { permanently_delete: true },
+    signal,
+  });
+
+  if (response.status !== 200) {
+    throw new Error(`Failed to delete project: ${response.status}`);
+  }
 }

--- a/src/components/calendar/CalendarEvent.tsx
+++ b/src/components/calendar/CalendarEvent.tsx
@@ -43,7 +43,7 @@ export function CalendarEvent({ eventInfo }: CalendarEventProps) {
       const durationText = `${Math.round(durationMinutes)}m`;
 
       return (
-        <div className="relative flex h-full items-center justify-between gap-1 overflow-hidden">
+        <div className="relative flex h-full items-start justify-between gap-1 overflow-hidden">
           {/* Zigzag left border */}
           <div className="absolute left-2 top-0 h-[100%]" style={zigzagStyle} />
 
@@ -51,12 +51,12 @@ export function CalendarEvent({ eventInfo }: CalendarEventProps) {
           <div className="absolute right-2 top-0 h-[100%]" style={zigzagStyle} />
 
           {/* Content */}
-          <div className="flex-1 px-5 py-0.5">
-            <span className="text-[11px] leading-tight sm:text-[10px]" style={{ color: "var(--break-text)" }}>
-              Break
+          <div className="flex-1 py-1 pl-5">
+            <span className="block text-[11px] leading-tight sm:text-[10px]" style={{ color: "var(--break-text)" }}>
+              {event.title || "Break"}
             </span>
           </div>
-          <div className="whitespace-nowrap pr-6 text-[10px] sm:text-xs" style={{ color: "var(--break-text)" }}>
+          <div className="whitespace-nowrap py-1 pr-5 text-[10px] sm:text-[10px]" style={{ color: "var(--break-text)" }}>
             {durationText}
           </div>
         </div>
@@ -75,7 +75,7 @@ export function CalendarEvent({ eventInfo }: CalendarEventProps) {
         {/* Content aligned top-left like normal events */}
         <div className="h-full px-5 py-1">
           <div className="text-[11px] font-medium leading-tight sm:text-[10px]" style={{ color: "var(--break-text)" }}>
-            Break
+            {event.title || "Break"}
           </div>
           <div className="mt-0.5 text-[10px] sm:text-[9px]" style={{ color: "var(--break-text)" }}>
             {eventInfo.timeText}

--- a/src/components/calendar/CalendarView.tsx
+++ b/src/components/calendar/CalendarView.tsx
@@ -39,6 +39,7 @@ interface CalendarViewProps {
   // Selection context menu props
   onCreateEvent?: (startDate: Date, endDate: Date) => void;
   onScheduleBreak?: (startDate: Date, endDate: Date) => void;
+  onRenameBreak?: (eventId: string) => void;
   // Touch and drag handlers
   onTouchStart?: (e: TouchEvent, eventId: string) => void;
   onTouchEnd?: () => void;
@@ -76,6 +77,7 @@ export function CalendarView({
   onEventDelete,
   onCreateEvent,
   onScheduleBreak,
+  onRenameBreak,
   onTouchStart,
   onTouchEnd,
   onDragStart,
@@ -340,7 +342,9 @@ export function CalendarView({
               <ContextMenuButton
                 icon={Edit}
                 onClick={() => {
-                  // TODO: Implement rename break functionality
+                  if (eventContextMenu.eventId && onRenameBreak) {
+                    onRenameBreak(eventContextMenu.eventId);
+                  }
                   hideContextMenu?.();
                 }}
               >

--- a/src/components/planner/CreationHotbar.tsx
+++ b/src/components/planner/CreationHotbar.tsx
@@ -1,0 +1,591 @@
+"use client";
+
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { Check, Image, Plus, X } from "lucide-react";
+import { createBreak, updateEvent } from "@/api/calendar";
+import { createProject } from "@/api/projects";
+import { DEFAULT_CALENDAR_ID, createTicket } from "@/api/tickets";
+import { CreationMode, CreationModeToggle } from "@/components/planner/CreationModeToggle";
+import { EpicSelect } from "@/components/planner/EpicSelect";
+import { FocusStatusSelect } from "@/components/planner/FocusStatusSelect";
+import { PrioritySelect } from "@/components/planner/PrioritySelect";
+import { ProjectSelect } from "@/components/planner/ProjectSelect";
+import { StatusSelect } from "@/components/planner/StatusSelect";
+import { TypeSelect } from "@/components/planner/TypeSelect";
+import { cn } from "@/lib/utils";
+import type { CalendarEvent } from "@/types/calendar";
+import type { Project } from "@/types/project";
+import type { Ticket, TicketStatus, TicketType } from "@/types/ticket";
+import { generateFocusKey } from "@/utils/generate-focus-key";
+
+interface CreationHotbarProps {
+  open: boolean;
+  projects: Project[];
+  allTickets?: Ticket[];
+  selectedProjectKey?: string;
+  defaultType?: TicketType;
+  initialDateRange?: { startDate: Date; endDate: Date } | null;
+  defaultMode?: CreationMode;
+  breakEventId?: string | null;
+  disableModeSwitch?: boolean;
+  initialTitle?: string;
+  onClose: () => void;
+  onClearDateRange?: () => void;
+  onBreakCreate?: () => void;
+  onBreakUpdate?: (eventId: string, title: string, startDate?: Date, endDate?: Date) => void;
+  onTicketAdd?: (ticket: Ticket) => void;
+  onTicketRemove?: (ticketId: string) => void;
+  onEventAdd?: (event: CalendarEvent) => void;
+  onEventRemove?: (eventId: string) => void;
+}
+
+/**
+ * Hotbar-style creation interface for tickets and focuses
+ * Appears centered on screen with no background blur
+ * Quick, temporary feel with click-outside-to-dismiss
+ */
+export function CreationHotbar({
+  open,
+  projects,
+  allTickets = [],
+  selectedProjectKey,
+  defaultType = "task",
+  initialDateRange,
+  defaultMode = "ticket",
+  breakEventId = null,
+  disableModeSwitch = false,
+  initialTitle,
+  onClose,
+  onClearDateRange,
+  onBreakCreate,
+  onBreakUpdate,
+  onTicketAdd,
+  onTicketRemove,
+  onEventAdd,
+  onEventRemove,
+}: CreationHotbarProps) {
+  const [mode, setMode] = useState<CreationMode>(defaultMode);
+  const [title, setTitle] = useState(initialTitle || (defaultMode === "break" ? "Break" : ""));
+  const [projectKey, setProjectKey] = useState<string | undefined>(selectedProjectKey ?? projects[0]?.project_key);
+  const [ticketType, setTicketType] = useState<TicketType>(defaultType);
+  const [status, setStatus] = useState<string>(defaultMode === "focus" ? "not started" : "To Do");
+  const [priority, setPriority] = useState<string | undefined>(undefined);
+  const [epicId, setEpicId] = useState<string | undefined>(undefined);
+  const [focusKeyOverride, setFocusKeyOverride] = useState<string>("");
+  const [expandedOptions, setExpandedOptions] = useState<Set<string>>(new Set());
+  const [description, setDescription] = useState("");
+  const [colour, setColour] = useState("");
+  const hotbarRef = useRef<HTMLDivElement>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+
+  // Auto-generate focus key from title
+  const focusKey = mode === "focus" ? generateFocusKey(title, focusKeyOverride) : "";
+
+  // Reset state when opening
+  useEffect(() => {
+    if (open) {
+      const timer = setTimeout(() => {
+        setMode(defaultMode);
+        setTitle(initialTitle || (defaultMode === "break" ? "Break" : ""));
+        setProjectKey(selectedProjectKey ?? projects[0]?.project_key);
+        setTicketType(defaultType);
+        setStatus(defaultMode === "focus" ? "not started" : "To Do");
+        setPriority(undefined);
+        setEpicId(undefined);
+        setFocusKeyOverride("");
+        setExpandedOptions(new Set());
+        setDescription("");
+        setColour("");
+      }, 0);
+      return () => clearTimeout(timer);
+    }
+  }, [open, selectedProjectKey, projects, defaultType, defaultMode, initialTitle]);
+
+  // Update status when mode changes
+  useEffect(() => {
+    if (mode === "focus") {
+      setStatus("not started");
+    } else if (mode === "ticket") {
+      setStatus("To Do");
+    }
+    // No status change needed for "break" mode
+  }, [mode]);
+
+  // Click outside handler
+  useEffect(() => {
+    if (!open) return;
+
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as Node;
+
+      // Don't close if clicking inside the hotbar
+      if (hotbarRef.current && !hotbarRef.current.contains(target)) {
+        // Don't close if clicking inside a select dropdown (radix portals)
+        const isSelectDropdown = (target as Element).closest('[role="listbox"], [role="dialog"], [data-radix-popper-content-wrapper]');
+        if (isSelectDropdown) return;
+
+        onClose();
+      }
+    };
+
+    const timer = setTimeout(() => {
+      document.addEventListener("mousedown", handleClickOutside);
+    }, 100);
+
+    return () => {
+      clearTimeout(timer);
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [open, onClose]);
+
+  // Toggle expanded option
+  const toggleOption = useCallback((option: string) => {
+    setExpandedOptions((prev) => {
+      const next = new Set(prev);
+      if (next.has(option)) {
+        next.delete(option);
+      } else {
+        next.add(option);
+      }
+      return next;
+    });
+  }, []);
+
+  // Submit handler
+  const handleSubmit = useCallback(async () => {
+    if (!title.trim()) return;
+
+    try {
+      if (mode === "break") {
+        if (!initialDateRange) {
+          console.error("Cannot create/update break without date range");
+          return;
+        }
+
+        if (breakEventId) {
+          // Update existing break event
+          await updateEvent(breakEventId, {
+            title: title.trim(),
+            start_date: initialDateRange.startDate.toISOString(),
+            end_date: initialDateRange.endDate.toISOString(),
+          });
+          onBreakUpdate?.(breakEventId, title.trim(), initialDateRange.startDate, initialDateRange.endDate);
+        } else {
+          // Create new break event
+          await createBreak({
+            title: title.trim(),
+            start_date: initialDateRange.startDate.toISOString(),
+            end_date: initialDateRange.endDate.toISOString(),
+          });
+          onBreakCreate?.();
+        }
+      } else if (mode === "ticket" && projectKey) {
+        const project = projects.find((p) => p.project_key === projectKey);
+        if (!project) return;
+
+        // Generate optimistic IDs
+        const optimisticTicketId = `optimistic-${Date.now()}`;
+        const optimisticEventId = initialDateRange ? `optimistic-event-${Date.now()}` : null;
+
+        // Create optimistic ticket
+        const optimisticTicket: Ticket = {
+          ticket_id: optimisticTicketId,
+          ticket_key: `${projectKey}-???`,
+          title: title.trim(),
+          ticket_type: ticketType,
+          ticket_status: status as TicketStatus, // Status is string, can be ticket or focus status
+          project_id: project.project_id,
+          project,
+          priority: priority || undefined,
+          colour: colour || undefined,
+          epic_id: epicId || undefined,
+          scheduled_date: initialDateRange ? initialDateRange.startDate.toISOString().split("T")[0] : undefined,
+        };
+
+        // Create optimistic event if date range is provided (but not for epics)
+        let optimisticEvent: CalendarEvent | null = null;
+        if (initialDateRange && optimisticEventId && ticketType !== "epic") {
+          optimisticEvent = {
+            ...optimisticTicket,
+            google_id: optimisticEventId,
+            start_date: initialDateRange.startDate.toISOString(),
+            end_date: initialDateRange.endDate.toISOString(),
+            google_calendar_id: DEFAULT_CALENDAR_ID,
+            isOptimistic: true,
+          };
+          onEventAdd?.(optimisticEvent);
+        }
+
+        // Add optimistic ticket to store
+        onTicketAdd?.(optimisticTicket);
+
+        try {
+          // Create ticket with all fields
+          const response = await createTicket({
+            title: title.trim(),
+            description: description || undefined,
+            projectId: project.project_id,
+            ticketType: ticketType,
+            ticketStatus: status,
+            priority: priority || undefined,
+            colour: colour || undefined,
+            epicId: epicId || undefined,
+            ...(initialDateRange &&
+              ticketType !== "epic" && {
+                startDate: initialDateRange.startDate.toISOString(),
+                endDate: initialDateRange.endDate.toISOString(),
+                googleCalendarId: DEFAULT_CALENDAR_ID,
+              }),
+          });
+
+          // Replace optimistic ticket with real data
+          onTicketRemove?.(optimisticTicketId);
+          onTicketAdd?.({ ...response, project });
+
+          // Replace optimistic event with real data if it exists (but not for epics)
+          if (optimisticEventId && response.google_id && ticketType !== "epic") {
+            onEventRemove?.(optimisticEventId);
+            onEventAdd?.({
+              ...response,
+              project,
+              start_date: initialDateRange!.startDate.toISOString(),
+              end_date: initialDateRange!.endDate.toISOString(),
+              google_calendar_id: DEFAULT_CALENDAR_ID,
+              google_id: response.google_id,
+            });
+          }
+        } catch (error) {
+          // Remove optimistic updates on error
+          onTicketRemove?.(optimisticTicketId);
+          if (optimisticEventId) {
+            onEventRemove?.(optimisticEventId);
+          }
+          console.error("Failed to create ticket:", error);
+          // TODO: Show error toast
+          throw error;
+        }
+      } else if (mode === "focus") {
+        // Create focus (project/epic)
+        await createProject({
+          title: title.trim(),
+          description: description || undefined,
+          colour: colour || undefined,
+          projectStatus: status,
+          projectKey: focusKeyOverride || undefined,
+        });
+      }
+
+      onClose();
+    } catch (error) {
+      console.error("Failed to create:", error);
+      // TODO: Show error toast
+    }
+  }, [
+    mode,
+    title,
+    description,
+    projectKey,
+    projects,
+    ticketType,
+    status,
+    priority,
+    colour,
+    epicId,
+    initialDateRange,
+    focusKeyOverride,
+    breakEventId,
+    onBreakCreate,
+    onBreakUpdate,
+    onClose,
+    onTicketAdd,
+    onTicketRemove,
+    onEventAdd,
+    onEventRemove,
+  ]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center" style={{ pointerEvents: "none" }}>
+      <div
+        ref={hotbarRef}
+        className="relative w-full max-w-2xl rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-elevated)] shadow-2xl"
+        style={{ pointerEvents: "auto" }}
+      >
+        {/* Main input section */}
+        <div
+          className={cn(
+            "mx-5 mb-4 mt-5 flex items-center gap-3 border-b pb-3",
+            mode === "focus" ? "border-purple-500" : mode === "break" ? "border-gray-400 dark:border-gray-600" : "border-[var(--accent)]",
+          )}
+        >
+          <input
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                handleSubmit();
+              } else if (e.key === "Escape") {
+                onClose();
+              }
+            }}
+            placeholder={mode === "ticket" ? "Enter your Ticket title..." : mode === "break" ? "Enter break title..." : "Enter your Focus title..."}
+            autoFocus
+            className="flex-1 bg-transparent text-lg font-medium text-[var(--text)] outline-none placeholder:text-[var(--text-muted)]"
+          />
+          <button
+            type="button"
+            className="flex h-8 w-8 items-center justify-center rounded-lg border border-[var(--border-subtle)] text-[var(--text-muted)] hover:border-[var(--accent-soft)] hover:bg-[var(--accent-subtle)] hover:text-[var(--accent)]"
+            title="Create from image (coming soon)"
+          >
+            <Image className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!title.trim()}
+            className={cn(
+              "flex h-8 w-8 items-center justify-center rounded-lg border transition-colors",
+              title.trim()
+                ? mode === "focus"
+                  ? "border-purple-500 bg-purple-500 text-white hover:border-green-500 hover:bg-green-500"
+                  : mode === "break"
+                    ? "border-gray-500 bg-gray-500 text-white hover:border-green-500 hover:bg-green-500"
+                    : "border-[var(--accent)] bg-[var(--accent)] text-white hover:border-green-500 hover:bg-green-500"
+                : "cursor-not-allowed border-[var(--border-subtle)] bg-[var(--surface)] text-[var(--text-disabled)] opacity-50",
+            )}
+            title="Create"
+          >
+            <Check className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Options row with mode toggle and dropdowns */}
+        <div
+          ref={scrollContainerRef}
+          className="flex items-center gap-1.5 overflow-x-auto py-1 pb-3"
+          style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
+        >
+          {/* Mode toggle */}
+          <div className="ml-5 flex-shrink-0">
+            <CreationModeToggle mode={mode} onModeChange={setMode} disabled={disableModeSwitch} hasTimeRange={!!initialDateRange} />
+          </div>
+
+          {/* Time range display */}
+          {initialDateRange && (mode === "ticket" || mode === "break") && (mode !== "ticket" || ticketType !== "epic") && (
+            <div className="flex flex-shrink-0 items-center gap-1.5 rounded-full border border-[var(--border-subtle)] bg-[var(--surface)] px-2 py-0.5 text-xs text-[var(--text-muted)]">
+              <span>
+                {initialDateRange.startDate.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" })} -{" "}
+                {initialDateRange.endDate.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" })}
+              </span>
+              {onClearDateRange && mode !== "break" && (
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onClearDateRange();
+                  }}
+                  className="flex h-3 w-3 items-center justify-center rounded-sm text-[var(--text-muted)] hover:bg-[var(--surface-hover)] hover:text-[var(--text)]"
+                >
+                  <X className="h-2.5 w-2.5" />
+                </button>
+              )}
+            </div>
+          )}
+
+          {mode === "ticket" && (
+            <>
+              {/* Focus dropdown */}
+              <div className="flex-shrink-0">
+                <ProjectSelect
+                  projectId={projects.find((p) => p.project_key === projectKey)?.project_id}
+                  projects={projects}
+                  onProjectChange={(projectId) => {
+                    const project = projects.find((p) => p.project_id === projectId);
+                    if (project) setProjectKey(project.project_key);
+                  }}
+                  className="h-auto rounded-full border border-[var(--border-subtle)] px-2 py-0.5 text-xs hover:border-[var(--accent-soft)] hover:bg-[var(--surface-hover)]"
+                />
+              </div>
+
+              {/* Type dropdown */}
+              <div className="flex-shrink-0">
+                <TypeSelect type={ticketType} onTypeChange={setTicketType} className="h-auto rounded-full px-2 py-0.5 text-xs" includeEpic />
+              </div>
+
+              {/* Status dropdown */}
+              <div className="flex-shrink-0">
+                <StatusSelect status={status as TicketStatus} onStatusChange={setStatus} className="h-auto rounded-full px-2 py-0.5 text-xs" />
+              </div>
+
+              {/* Epic dropdown - only for non-epic tickets */}
+              {ticketType !== "epic" && (
+                <div className="flex-shrink-0">
+                  <EpicSelect
+                    epicId={epicId}
+                    tickets={allTickets}
+                    projectId={projects.find((p) => p.project_key === projectKey)?.project_id}
+                    onEpicChange={(id) => setEpicId(id ?? undefined)}
+                    className="h-auto rounded-full border border-[var(--border-subtle)] px-2 py-0.5 text-xs hover:border-[var(--accent-soft)] hover:bg-[var(--surface-hover)]"
+                    placeholder="Select Epic"
+                  />
+                </div>
+              )}
+
+              {/* Priority dropdown */}
+              <div className="flex-shrink-0">
+                <PrioritySelect
+                  priority={priority}
+                  onPriorityChange={(p) => setPriority(p ?? undefined)}
+                  className="h-auto rounded-full border border-[var(--border-subtle)] px-2 py-0.5 text-xs hover:border-[var(--accent-soft)] hover:bg-[var(--surface-hover)]"
+                  placeholder="Priority"
+                />
+              </div>
+
+              {/* + Colour button - only for epic tickets */}
+              {ticketType === "epic" && (
+                <button
+                  type="button"
+                  onClick={() => toggleOption("colour")}
+                  className={cn(
+                    "flex flex-shrink-0 items-center gap-1 whitespace-nowrap rounded-full border px-2 py-0.5 text-xs transition-colors",
+                    expandedOptions.has("colour")
+                      ? "border-[var(--accent)] bg-[var(--accent-soft)] text-[var(--accent)]"
+                      : "border-[var(--accent-soft)] bg-[var(--accent-subtle)] text-[var(--accent)] hover:bg-[var(--accent-soft)]",
+                  )}
+                >
+                  {expandedOptions.has("colour") ? <X className="h-3 w-3" /> : <Plus className="h-3 w-3" />}
+                  Colour
+                </button>
+              )}
+
+              {/* + Description button */}
+              <button
+                type="button"
+                onClick={() => toggleOption("description")}
+                className={cn(
+                  "mr-5 flex flex-shrink-0 items-center gap-1 whitespace-nowrap rounded-full border px-2 py-0.5 text-xs transition-colors",
+                  expandedOptions.has("description")
+                    ? "border-[var(--accent)] bg-[var(--accent-soft)] text-[var(--accent)]"
+                    : "border-[var(--accent-soft)] bg-[var(--accent-subtle)] text-[var(--accent)] hover:bg-[var(--accent-soft)]",
+                )}
+              >
+                {expandedOptions.has("description") ? <X className="h-3 w-3" /> : <Plus className="h-3 w-3" />}
+                Description
+              </button>
+            </>
+          )}
+
+          {mode === "focus" && (
+            <>
+              {/* Key preview */}
+              <button
+                type="button"
+                onClick={() => toggleOption("key")}
+                className="flex flex-shrink-0 items-center gap-1.5 rounded-full border border-[var(--border-subtle)] bg-[var(--surface)] px-2 py-0.5 text-xs text-[var(--text-muted)] hover:border-[var(--accent-soft)] hover:bg-[var(--surface-hover)]"
+              >
+                <span>Key: {focusKey || "Auto"}</span>
+              </button>
+
+              {/* Status dropdown */}
+              <div className="flex-shrink-0">
+                <FocusStatusSelect status={status} onStatusChange={setStatus} className="h-auto rounded-full px-2 py-0.5 text-xs" />
+              </div>
+
+              {/* + Colour button */}
+              <button
+                type="button"
+                onClick={() => toggleOption("colour")}
+                className={cn(
+                  "flex flex-shrink-0 items-center gap-1 whitespace-nowrap rounded-full border px-2 py-0.5 text-xs transition-colors",
+                  expandedOptions.has("colour")
+                    ? "border-purple-500 bg-purple-100 text-purple-600 dark:bg-purple-950 dark:text-purple-400"
+                    : "border-purple-300 bg-purple-50 text-purple-600 hover:bg-purple-100 dark:border-purple-800 dark:bg-purple-950/50 dark:text-purple-400 dark:hover:bg-purple-950",
+                )}
+              >
+                {expandedOptions.has("colour") ? <X className="h-3 w-3" /> : <Plus className="h-3 w-3" />}
+                Colour
+              </button>
+
+              {/* + Description button */}
+              <button
+                type="button"
+                onClick={() => toggleOption("description")}
+                className={cn(
+                  "mr-5 flex flex-shrink-0 items-center gap-1 whitespace-nowrap rounded-full border px-2 py-0.5 text-xs transition-colors",
+                  expandedOptions.has("description")
+                    ? "border-purple-500 bg-purple-100 text-purple-600 dark:bg-purple-950 dark:text-purple-400"
+                    : "border-purple-300 bg-purple-50 text-purple-600 hover:bg-purple-100 dark:border-purple-800 dark:bg-purple-950/50 dark:text-purple-400 dark:hover:bg-purple-950",
+                )}
+              >
+                {expandedOptions.has("description") ? <X className="h-3 w-3" /> : <Plus className="h-3 w-3" />}
+                Description
+              </button>
+            </>
+          )}
+        </div>
+
+        {/* Expandable options content area */}
+        {expandedOptions.size > 0 && (
+          <div className="mx-5 mb-5 mt-4 space-y-3">
+            {expandedOptions.has("key") && (
+              <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)] p-3">
+                <div className="flex items-center gap-3">
+                  <label htmlFor="key-input" className="text-sm text-[var(--text-muted)]">
+                    Key Override:
+                  </label>
+                  <input
+                    id="key-input"
+                    type="text"
+                    value={focusKeyOverride}
+                    onChange={(e) => setFocusKeyOverride(e.target.value)}
+                    placeholder="e.g., ABC"
+                    className="flex-1 rounded border border-[var(--border-subtle)] bg-transparent px-2 py-1 text-sm text-[var(--text)] outline-none"
+                  />
+                </div>
+              </div>
+            )}
+
+            {expandedOptions.has("description") && (
+              <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)] p-3">
+                <textarea
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  placeholder="Add a description..."
+                  rows={3}
+                  className="w-full resize-none bg-transparent text-sm text-[var(--text)] outline-none placeholder:text-[var(--text-muted)]"
+                />
+              </div>
+            )}
+
+            {expandedOptions.has("colour") && (
+              <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)] p-3">
+                <div className="flex items-center gap-3">
+                  <label htmlFor="colour-input" className="text-sm text-[var(--text-muted)]">
+                    Colour:
+                  </label>
+                  <input
+                    id="colour-input"
+                    type="color"
+                    value={colour || "#2563eb"}
+                    onChange={(e) => setColour(e.target.value)}
+                    className="h-8 w-16 cursor-pointer rounded border border-[var(--border-subtle)]"
+                  />
+                  <input
+                    type="text"
+                    value={colour}
+                    onChange={(e) => setColour(e.target.value)}
+                    placeholder="#2563eb"
+                    className="flex-1 rounded border border-[var(--border-subtle)] bg-transparent px-2 py-1 text-sm text-[var(--text)] outline-none"
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/planner/CreationModeToggle.tsx
+++ b/src/components/planner/CreationModeToggle.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import React from "react";
+import { cn } from "@/lib/utils";
+
+export type CreationMode = "ticket" | "focus" | "break";
+
+interface CreationModeToggleProps {
+  mode: CreationMode;
+  onModeChange: (mode: CreationMode) => void;
+  disabled?: boolean;
+  hasTimeRange?: boolean;
+}
+
+/**
+ * Toggle component for switching between Ticket and Focus creation modes
+ * Displays as a pill with two sides that flip highlight on click
+ */
+export function CreationModeToggle({ mode, onModeChange: _onModeChange, disabled = false, hasTimeRange = false }: CreationModeToggleProps) {
+  const isBreakDisabled = disabled || !hasTimeRange;
+
+  return (
+    <div className={cn("inline-flex rounded-full border border-[var(--border-subtle)] bg-[var(--surface)] p-0.5", disabled && "cursor-not-allowed opacity-50")}>
+      <button
+        type="button"
+        onClick={() => _onModeChange("ticket")}
+        disabled={disabled}
+        className={`min-w-[50px] rounded-full px-2 py-0.5 text-xs font-medium transition-all duration-200 ${
+          mode === "ticket" ? "bg-[var(--accent-soft)] text-[var(--accent)] shadow-sm" : "text-[var(--text-muted)] hover:text-[var(--text)]"
+        } ${disabled ? "cursor-not-allowed" : ""}`}
+      >
+        Ticket
+      </button>
+      <button
+        type="button"
+        onClick={() => _onModeChange("focus")}
+        disabled={disabled}
+        className={`min-w-[50px] rounded-full px-2 py-0.5 text-xs font-medium transition-all duration-200 ${
+          mode === "focus"
+            ? "bg-purple-100 text-purple-600 shadow-sm dark:bg-purple-950 dark:text-purple-400"
+            : "text-[var(--text-muted)] hover:text-[var(--text)]"
+        } ${disabled ? "cursor-not-allowed" : ""}`}
+      >
+        Focus
+      </button>
+      <button
+        type="button"
+        onClick={() => _onModeChange("break")}
+        disabled={isBreakDisabled}
+        className={cn(
+          "min-w-[50px] rounded-full px-2 py-0.5 text-xs font-medium transition-all duration-200",
+          mode === "break" ? "bg-gray-200 text-gray-700 shadow-sm dark:bg-gray-800 dark:text-gray-300" : "text-[var(--text-muted)] hover:text-[var(--text)]",
+          isBreakDisabled && "cursor-not-allowed opacity-50",
+        )}
+      >
+        Break
+      </button>
+    </div>
+  );
+}

--- a/src/components/planner/EpicSelect.tsx
+++ b/src/components/planner/EpicSelect.tsx
@@ -13,9 +13,10 @@ interface EpicSelectProps {
   projectId?: string;
   onEpicChange: (epicId: string | null) => void;
   className?: string;
+  placeholder?: string;
 }
 
-export function EpicSelect({ epicId, tickets, projectId, onEpicChange, className }: EpicSelectProps) {
+export function EpicSelect({ epicId, tickets, projectId, onEpicChange, className, placeholder = "-" }: EpicSelectProps) {
   const [optimisticEpicId, setOptimisticEpicId] = useState(epicId);
   const { epics } = useEpics(tickets, projectId);
 
@@ -33,8 +34,8 @@ export function EpicSelect({ epicId, tickets, projectId, onEpicChange, className
   };
 
   const getEpicTitle = (id: string | undefined) => {
-    if (!id) return "-";
-    return getEpic(id)?.title ?? "-";
+    if (!id) return placeholder;
+    return getEpic(id)?.title ?? placeholder;
   };
 
   const handleValueChange = (newValue: string) => {
@@ -56,20 +57,22 @@ export function EpicSelect({ epicId, tickets, projectId, onEpicChange, className
       <Select value={optimisticEpicId || "__none__"} onValueChange={handleValueChange}>
         <SelectTrigger
           className={cn(
-            "h-auto w-auto rounded-md border-0 px-2 py-1 text-sm font-medium shadow-none transition-colors hover:bg-[var(--surface-hover)] focus:ring-0 [&>svg]:hidden",
-            optimisticEpicId && "pr-7",
+            "h-auto w-auto max-w-[200px] rounded-md border-0 px-2 py-1 text-sm font-medium shadow-none transition-colors hover:bg-[var(--surface-hover)] focus:ring-0 [&>svg]:hidden",
+            optimisticEpicId && "pr-8",
             className,
           )}
           onClick={(e) => e.stopPropagation()}
         >
           <SelectValue>
             {optimisticEpicId ? (
-              <div className="flex items-center gap-2">
-                {getEpic(optimisticEpicId)?.colour && <div className="h-4 w-1 rounded-full" style={{ backgroundColor: getEpic(optimisticEpicId)?.colour }} />}
-                <span>{getEpicTitle(optimisticEpicId)}</span>
+              <div className="flex max-w-full items-center gap-2 overflow-hidden pr-3">
+                {getEpic(optimisticEpicId)?.colour && (
+                  <div className="h-4 w-1 flex-shrink-0 rounded-full" style={{ backgroundColor: getEpic(optimisticEpicId)?.colour }} />
+                )}
+                <span className="truncate">{getEpicTitle(optimisticEpicId)}</span>
               </div>
             ) : (
-              "-"
+              <span>{placeholder}</span>
             )}
           </SelectValue>
         </SelectTrigger>
@@ -95,7 +98,7 @@ export function EpicSelect({ epicId, tickets, projectId, onEpicChange, className
         <button
           onClick={handleClear}
           onMouseDown={(e) => e.preventDefault()}
-          className="absolute right-2 rounded-sm opacity-50 transition-opacity hover:opacity-100"
+          className="absolute right-1.5 top-1/2 -translate-y-1/2 rounded-sm opacity-50 transition-opacity hover:opacity-100"
           aria-label="Clear epic"
         >
           <X className="h-3 w-3" />

--- a/src/components/planner/FocusStatusSelect.tsx
+++ b/src/components/planner/FocusStatusSelect.tsx
@@ -7,15 +7,15 @@ import { PillSelect } from "@/ui/pill-select";
 const STATUS_GROUPS = [
   {
     label: "To-do",
-    options: ["Inactive", "Backlog", "Not Started"],
+    options: ["inactive", "backlog", "not started"],
   },
   {
     label: "In progress",
-    options: ["In Progress"],
+    options: ["in progress"],
   },
   {
     label: "Complete",
-    options: ["Done", "Archived"],
+    options: ["done", "archived"],
   },
 ];
 
@@ -24,6 +24,14 @@ interface FocusStatusSelectProps {
   onStatusChange: (newStatus: string) => void;
   className?: string;
 }
+
+const getDisplayName = (status: string): string => {
+  // Capitalize first letter of each word
+  return status
+    .split(" ")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+};
 
 const getStatusPillClasses = (status: string): string => {
   const normalized = status?.toLowerCase();
@@ -50,11 +58,12 @@ const getStatusHoverClasses = (status: string): string => {
 export function FocusStatusSelect({ status, onStatusChange, className }: FocusStatusSelectProps) {
   return (
     <PillSelect
-      value={status || "Not Started"}
+      value={status || "not started"}
       onChange={onStatusChange}
       groups={STATUS_GROUPS}
       getPillClasses={getStatusPillClasses}
       getHoverClasses={getStatusHoverClasses}
+      getDisplayName={getDisplayName}
       align="end"
       className={cn("h-6 rounded-full", className)}
     />

--- a/src/components/planner/FocusesSidebar.tsx
+++ b/src/components/planner/FocusesSidebar.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from "react";
 import { ChevronDown, ClipboardList, Diamond, FolderKanban, Plus, Target } from "lucide-react";
+import { CreationHotbar } from "@/components/planner/CreationHotbar";
 import { TicketCard } from "@/components/planner/TicketCard";
 import { cn } from "@/lib/utils";
 import type { Project } from "@/types/project";
@@ -27,7 +28,7 @@ type TabType = "epics" | "programs";
  */
 export function FocusesSidebar({ projects, tickets, selectedProjectKey, onProjectChange, onTicketClick, onStatusChange, onProjectEdit }: FocusesSidebarProps) {
   const [activeTab, setActiveTab] = useState<TabType>("epics");
-  // const [isCreateEpicModalOpen, setIsCreateEpicModalOpen] = useState(false); // TODO: Implement epic creation modal
+  const [isCreateHotbarOpen, setIsCreateHotbarOpen] = useState(false);
 
   const currentTickets = React.useMemo(() => (selectedProjectKey ? tickets[selectedProjectKey] || [] : []), [selectedProjectKey, tickets]);
 
@@ -38,10 +39,9 @@ export function FocusesSidebar({ projects, tickets, selectedProjectKey, onProjec
 
   const selectedProject = projects.find((p) => p.project_key === selectedProjectKey);
 
-  const handleOpenCreateEpicModal = () => {
+  const handleOpenCreateHotbar = () => {
     if (!selectedProjectKey && projects.length === 0) return;
-    // setIsCreateEpicModalOpen(true); // TODO: Implement epic creation modal
-    console.log("Create epic modal not yet implemented");
+    setIsCreateHotbarOpen(true);
   };
 
   const handleEditProject = () => {
@@ -100,7 +100,7 @@ export function FocusesSidebar({ projects, tickets, selectedProjectKey, onProjec
         <div className="flex items-center justify-between">
           {/* Create epic button */}
           <button
-            onClick={handleOpenCreateEpicModal}
+            onClick={handleOpenCreateHotbar}
             disabled={!selectedProjectKey}
             className={cn(
               "flex h-8 w-8 items-center justify-center rounded-md transition-colors",
@@ -164,7 +164,13 @@ export function FocusesSidebar({ projects, tickets, selectedProjectKey, onProjec
         </div>
       </ScrollArea>
 
-      {/* TODO: Add TicketCreateModal for epics when needed */}
+      <CreationHotbar
+        open={isCreateHotbarOpen}
+        projects={projects}
+        selectedProjectKey={selectedProjectKey}
+        defaultType="epic"
+        onClose={() => setIsCreateHotbarOpen(false)}
+      />
     </div>
   );
 }

--- a/src/components/planner/PrioritySelect.tsx
+++ b/src/components/planner/PrioritySelect.tsx
@@ -9,6 +9,7 @@ interface PrioritySelectProps {
   priority: string | undefined;
   onPriorityChange: (priority: string | null) => void;
   className?: string;
+  placeholder?: string;
 }
 
 const PRIORITY_OPTIONS = [
@@ -36,7 +37,7 @@ function getPriorityColor(priority: string | undefined): string {
   return "text-[var(--text-muted)]";
 }
 
-export function PrioritySelect({ priority, onPriorityChange, className }: PrioritySelectProps) {
+export function PrioritySelect({ priority, onPriorityChange, className, placeholder = "-" }: PrioritySelectProps) {
   const [optimisticPriority, setOptimisticPriority] = useState(priority);
 
   // Sync optimistic value with prop changes (in case of API errors or external updates)
@@ -65,16 +66,16 @@ export function PrioritySelect({ priority, onPriorityChange, className }: Priori
       <Select value={optimisticPriority || "__none__"} onValueChange={handleValueChange}>
         <SelectTrigger
           className={cn(
-            "h-auto w-auto rounded-md border-0 px-2 py-1 text-sm font-medium shadow-none transition-colors hover:bg-[var(--surface-hover)] focus:ring-0 [&>svg]:hidden",
-            optimisticPriority && "pr-7",
+            "h-auto w-auto max-w-[200px] rounded-md border-0 px-2 py-1 text-sm font-medium shadow-none transition-colors hover:bg-[var(--surface-hover)] focus:ring-0 [&>svg]:hidden",
+            optimisticPriority && "pr-8",
             className,
           )}
           onClick={(e) => e.stopPropagation()}
         >
           <SelectValue>
-            <div className="flex items-center gap-1.5">
-              {optimisticPriority && getPriorityIcon(optimisticPriority)}
-              <span>{currentOption?.label ?? "-"}</span>
+            <div className={cn("flex max-w-full items-center gap-1.5 overflow-hidden", optimisticPriority && "pr-3")}>
+              {optimisticPriority && <span className="flex-shrink-0">{getPriorityIcon(optimisticPriority)}</span>}
+              <span className="truncate">{currentOption?.label ?? placeholder}</span>
             </div>
           </SelectValue>
         </SelectTrigger>
@@ -103,7 +104,7 @@ export function PrioritySelect({ priority, onPriorityChange, className }: Priori
         <button
           onClick={handleClear}
           onMouseDown={(e) => e.preventDefault()}
-          className="absolute right-2 rounded-sm opacity-50 transition-opacity hover:opacity-100"
+          className="absolute right-1.5 top-1/2 -translate-y-1/2 rounded-sm opacity-50 transition-opacity hover:opacity-100"
           aria-label="Clear priority"
         >
           <X className="h-3 w-3" />

--- a/src/components/planner/TicketsSidebar.tsx
+++ b/src/components/planner/TicketsSidebar.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useRef } from "react";
 import { Draggable } from "@fullcalendar/interaction";
 import { Archive, CalendarDays, ChevronDown, Clock, Feather, Plus } from "lucide-react";
 import { CalendarCard } from "@/components/calendar/CalendarCard";
-import { TicketCreateModal } from "@/components/modals/TicketCreateModal";
+import { CreationHotbar } from "@/components/planner/CreationHotbar";
 import { TicketCard } from "@/components/planner/TicketCard";
 import { cn } from "@/lib/utils";
 import type { CalendarEvent } from "@/types/calendar";
@@ -45,7 +45,7 @@ export function TicketsSidebar({
   onScheduleTicket,
   onUnscheduleTicket,
   onStatusChange,
-  onCreateTicket,
+  onCreateTicket: _onCreateTicket,
   onUnselectCalendar,
 }: TicketsSidebarProps) {
   const ticketsListRef = useRef<HTMLDivElement>(null);
@@ -417,13 +417,7 @@ export function TicketsSidebar({
         </div>
       </ScrollArea>
 
-      <TicketCreateModal
-        open={isCreateModalOpen}
-        projects={projects}
-        selectedProjectKey={selectedProjectKey}
-        onClose={() => setIsCreateModalOpen(false)}
-        onCreateTicket={onCreateTicket}
-      />
+      <CreationHotbar open={isCreateModalOpen} projects={projects} selectedProjectKey={selectedProjectKey} onClose={() => setIsCreateModalOpen(false)} />
 
       {ticketSchedulePicker && (
         <div

--- a/src/components/planner/TypeSelect.tsx
+++ b/src/components/planner/TypeSelect.tsx
@@ -11,14 +11,17 @@ interface TypeSelectProps {
   onTypeChange: (newType: TicketType) => void;
   className?: string;
   disabled?: boolean;
+  includeEpic?: boolean;
 }
 
-export function TypeSelect({ type, onTypeChange, className, disabled }: TypeSelectProps) {
+export function TypeSelect({ type, onTypeChange, className, disabled, includeEpic = false }: TypeSelectProps) {
+  const options = includeEpic ? ([...TYPE_OPTIONS, "epic"] as TicketType[]) : TYPE_OPTIONS;
+
   return (
     <PillSelect
       value={type}
       onChange={onTypeChange}
-      groups={[{ label: "Ticket Type", options: TYPE_OPTIONS }]}
+      groups={[{ label: "Ticket Type", options }]}
       getPillClasses={typePillClasses}
       getHoverClasses={typeHoverClasses}
       getDisplayName={getTypeDisplayName}

--- a/src/hooks/useHotkeys.ts
+++ b/src/hooks/useHotkeys.ts
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect } from "react";
+
+export interface HotkeyConfig {
+  key: string;
+  shiftKey?: boolean;
+  ctrlKey?: boolean;
+  metaKey?: boolean;
+  altKey?: boolean;
+  callback: (event: KeyboardEvent) => void;
+  preventDefault?: boolean;
+  enabled?: boolean;
+}
+
+/**
+ * Hook to register keyboard shortcuts
+ * @param hotkeys - Array of hotkey configurations
+ *
+ * @example
+ * useHotkeys([
+ *   {
+ *     key: ' ', // Space
+ *     shiftKey: true,
+ *     callback: () => console.log('Shift + Space pressed'),
+ *     preventDefault: true
+ *   }
+ * ]);
+ */
+export function useHotkeys(hotkeys: HotkeyConfig[]) {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      for (const hotkey of hotkeys) {
+        // Skip if hotkey is disabled
+        if (hotkey.enabled === false) continue;
+
+        // Check if all modifiers match
+        const shiftMatch = hotkey.shiftKey === undefined || hotkey.shiftKey === event.shiftKey;
+        const ctrlMatch = hotkey.ctrlKey === undefined || hotkey.ctrlKey === event.ctrlKey;
+        const metaMatch = hotkey.metaKey === undefined || hotkey.metaKey === event.metaKey;
+        const altMatch = hotkey.altKey === undefined || hotkey.altKey === event.altKey;
+        const keyMatch = hotkey.key.toLowerCase() === event.key.toLowerCase();
+
+        if (keyMatch && shiftMatch && ctrlMatch && metaMatch && altMatch) {
+          // Don't trigger hotkeys when typing in input fields
+          const target = event.target as HTMLElement;
+          const isInput = target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable;
+
+          if (!isInput) {
+            if (hotkey.preventDefault) {
+              event.preventDefault();
+            }
+            hotkey.callback(event);
+            break;
+          }
+        }
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [hotkeys]);
+}

--- a/src/types/calendar.ts
+++ b/src/types/calendar.ts
@@ -19,6 +19,18 @@ export interface EventsResponse {
   events: CalendarEvent[];
 }
 
+export interface BreakEvent {
+  google_id: string;
+  title: string;
+  start_date: string;
+  end_date: string;
+  is_break: true;
+}
+
+export interface CreateBreakResponse {
+  break: BreakEvent;
+}
+
 export interface CalendarEventExtendedProps {
   showBand?: boolean;
   bandColor?: string;

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -9,6 +9,7 @@ export interface Project {
   notion_id: string;
   title: string;
   colour?: string;
+  description?: string;
 }
 
 export interface ProjectsResponse {

--- a/src/utils/generate-focus-key.ts
+++ b/src/utils/generate-focus-key.ts
@@ -1,0 +1,47 @@
+/**
+ * Generate a focus/project key from a title following Notion formula logic.
+ *
+ * Logic:
+ * 1. If override is provided, use it (uppercased, max 4 chars)
+ * 2. Otherwise, split title by spaces and filter for words containing only letters
+ * 3. If 1 valid word: take first 4 characters
+ * 4. If 2 valid words: take first character of each word
+ * 5. If 3+ valid words: take first character of first 3 words
+ * 6. Uppercase the result and enforce 4 character maximum
+ *
+ * @param title - Focus/project title
+ * @param override - Optional override key (max 4 characters)
+ * @returns Generated key (uppercased, max 4 characters)
+ *
+ * @example
+ * generateFocusKey("Command Centre") // "CC"
+ * generateFocusKey("Python") // "PYTH"
+ * generateFocusKey("AI Model Service") // "AMS"
+ * generateFocusKey("Test", "CUSTOM") // "CUST"
+ */
+export function generateFocusKey(title: string, override?: string): string {
+  if (override) {
+    // Keep only alphabetical characters, uppercase, max 4 chars
+    const cleanOverride = override.replace(/[^A-Za-z]/g, "");
+    return cleanOverride.toUpperCase().slice(0, 4) || "PRJ";
+  }
+
+  // Split by spaces and filter for words containing only letters
+  const validNames = title.split(" ").filter((word) => /^[A-Za-z]+$/.test(word));
+
+  if (validNames.length === 0) {
+    // Fallback: use first 4 chars of title if no valid words
+    return title.slice(0, 4).toUpperCase() || "PRJ";
+  }
+
+  if (validNames.length === 1) {
+    // Single word: take first 4 characters
+    return validNames[0].slice(0, 4).toUpperCase();
+  } else if (validNames.length === 2) {
+    // Two words: take first char of each
+    return (validNames[0][0] + validNames[1][0]).toUpperCase().slice(0, 4);
+  } else {
+    // Three or more words: take first char of first 3 words
+    return (validNames[0][0] + validNames[1][0] + validNames[2][0]).toUpperCase().slice(0, 4);
+  }
+}


### PR DESCRIPTION
…cuses

- Redesign ticket/focus creation from modal to hotbar-style popup
- Add toggle between Ticket and Focus creation modes
- Implement horizontal scrollable expandable options with caret indicators
- Position hotbar centered with no background blur or shading
- Support default type detection (Event from calendar, Task from + button)
- Add image icon button for future create from image flow
- Maintain quick, temporary feel with click-outside-to-dismiss behavior